### PR TITLE
Metasampler, MultiBatchSampler, SamplerControler

### DIFF
--- a/src/Trajectories.jl
+++ b/src/Trajectories.jl
@@ -1,7 +1,7 @@
 module Trajectories
 
 include("samplers.jl")
-include("controlers.jl")
+include("controllers.jl")
 include("traces.jl")
 include("episodes.jl")
 include("trajectory.jl")

--- a/src/controlers.jl
+++ b/src/controlers.jl
@@ -1,4 +1,4 @@
-export InsertSampleRatioControler, AsyncInsertSampleRatioControler
+export InsertSampleRatioControler, InsertSampleControler, AsyncInsertSampleRatioControler
 
 mutable struct InsertSampleRatioControler
     ratio::Float64
@@ -25,6 +25,36 @@ end
 function on_sample!(c::InsertSampleRatioControler)
     if c.n_inserted >= c.threshold
         if c.n_sampled <= (c.n_inserted - c.threshold) * c.ratio
+            c.n_sampled += 1
+            true
+        end
+    end
+end
+
+"""
+    InsertSampleControler(n, threshold)
+
+Used in [`Trajectory`](@ref). The `threshold` means the minimal number of
+insertings before sampling. The `n` is the number of samples until stopping.
+"""
+mutable struct InsertSampleControler
+    n::Int
+    threshold::Int
+    n_inserted::Int
+    n_sampled::Int
+end
+
+InsertSampleControler(n, threshold) = InsertSampleControler(n, threshold, 0, 0)
+
+function on_insert!(c::InsertSampleControler, n::Int)
+    if n > 0
+        c.n_inserted += n
+    end
+end
+
+function on_sample!(c::InsertSampleControler)
+    if c.n_inserted >= c.threshold
+        if c.n_sampled < c.n
             c.n_sampled += 1
             true
         end

--- a/src/controllers.jl
+++ b/src/controllers.jl
@@ -1,6 +1,6 @@
-export InsertSampleRatioControler, InsertSampleControler, AsyncInsertSampleRatioControler
+export InsertSampleRatioController, InsertSampleController, AsyncInsertSampleRatioController
 
-mutable struct InsertSampleRatioControler
+mutable struct InsertSampleRatioController
     ratio::Float64
     threshold::Int
     n_inserted::Int
@@ -8,21 +8,21 @@ mutable struct InsertSampleRatioControler
 end
 
 """
-    InsertSampleRatioControler(ratio, threshold)
+    InsertSampleRatioController(ratio, threshold)
 
 Used in [`Trajectory`](@ref). The `threshold` means the minimal number of
 insertings before sampling. The `ratio` balances the number of insertings and
 the number of samplings.
 """
-InsertSampleRatioControler(ratio, threshold) = InsertSampleRatioControler(ratio, threshold, 0, 0)
+InsertSampleRatioController(ratio, threshold) = InsertSampleRatioController(ratio, threshold, 0, 0)
 
-function on_insert!(c::InsertSampleRatioControler, n::Int)
+function on_insert!(c::InsertSampleRatioController, n::Int)
     if n > 0
         c.n_inserted += n
     end
 end
 
-function on_sample!(c::InsertSampleRatioControler)
+function on_sample!(c::InsertSampleRatioController)
     if c.n_inserted >= c.threshold
         if c.n_sampled <= (c.n_inserted - c.threshold) * c.ratio
             c.n_sampled += 1
@@ -32,27 +32,27 @@ function on_sample!(c::InsertSampleRatioControler)
 end
 
 """
-    InsertSampleControler(n, threshold)
+    InsertSampleController(n, threshold)
 
 Used in [`Trajectory`](@ref). The `threshold` means the minimal number of
 insertings before sampling. The `n` is the number of samples until stopping.
 """
-mutable struct InsertSampleControler
+mutable struct InsertSampleController
     n::Int
     threshold::Int
     n_inserted::Int
     n_sampled::Int
 end
 
-InsertSampleControler(n, threshold) = InsertSampleControler(n, threshold, 0, 0)
+InsertSampleController(n, threshold) = InsertSampleController(n, threshold, 0, 0)
 
-function on_insert!(c::InsertSampleControler, n::Int)
+function on_insert!(c::InsertSampleController, n::Int)
     if n > 0
         c.n_inserted += n
     end
 end
 
-function on_sample!(c::InsertSampleControler)
+function on_sample!(c::InsertSampleController)
     if c.n_inserted >= c.threshold
         if c.n_sampled < c.n
             c.n_sampled += 1
@@ -63,7 +63,7 @@ end
 
 #####
 
-mutable struct AsyncInsertSampleRatioControler
+mutable struct AsyncInsertSampleRatioController
     ratio::Float64
     threshold::Int
     n_inserted::Int
@@ -72,7 +72,7 @@ mutable struct AsyncInsertSampleRatioControler
     ch_out::Channel
 end
 
-function AsyncInsertSampleRatioControler(
+function AsyncInsertSampleRatioController(
     ratio,
     threshold,
     ; ch_in_sz=1,
@@ -80,7 +80,7 @@ function AsyncInsertSampleRatioControler(
     n_inserted=0,
     n_sampled=0
 )
-    AsyncInsertSampleRatioControler(
+    AsyncInsertSampleRatioController(
         ratio,
         threshold,
         n_inserted,

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -110,7 +110,7 @@ function Base.convert(r::Type{Term.AbstractRenderable}, t::Trajectory; width=88)
     Panel(
         convert(r, t.container; width=width - 8) /
         Panel(convert(Term.Tree, t.sampler); title="sampler", style="yellow3", fit=true, width=width - 8) /
-        Panel(convert(Term.Tree, t.controler); title="controler", style="yellow3", fit=true, width=width - 8);
+        Panel(convert(Term.Tree, t.controller); title="controller", style="yellow3", fit=true, width=width - 8);
         title="Trajectory",
         style="yellow3",
         width=width,

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -1,8 +1,10 @@
-export BatchSampler
+export BatchSampler, MetaSampler, MultiBatchSampler
 
 using Random
 
-struct BatchSampler
+abstract type AbstractSampler end
+
+struct BatchSampler <: AbstractSampler
     batch_size::Int
     rng::Random.AbstractRNG
     transformer::Any
@@ -16,3 +18,40 @@ Uniformly sample a batch of examples for each trace.
 See also [`sample`](@ref).
 """
 BatchSampler(batch_size; rng=Random.GLOBAL_RNG, transformer=identity) = BatchSampler(batch_size, rng, identity)
+
+"""
+    MetaSampler(::NamedTuple)
+
+Wraps a NamedTuple containing multiple samplers. When sampled, returns a named tuple with a batch from each sampler.
+Used internally for algorithms that sample multiple times per epoch.
+
+# Example
+
+MetaSampler(policy = BatchSampler(10), critic = BatchSampler(100))
+"""
+struct MetaSampler{names, T} <: AbstractSampler
+    samplers::NamedTuple{names, T}
+end
+
+MetaSampler(; kw...) = MetaSampler(NamedTuple(kw))
+
+function sample(s::MetaSampler, t)
+   (;[(k, sample(v, t)) for (k,v) in pairs(s.samplers)]...)
+end
+
+
+"""
+    MultiBatchSampler(sampler, n)
+
+Wraps a sampler. When sampled, will sample n batches using sampler. Useful in combination with MetaSampler to allow different sampling rates between samplers.
+
+# Example
+
+MetaSampler(policy = MultiBatchSampler(BatchSampler(10), 3), critic = MultiBatchSampler(BatchSampler(100), 5))
+"""
+struct MultiBatchSampler{S <: AbstractSampler} <: AbstractSampler
+    sampler::S
+    n::Int
+end
+
+sample(m::MultiBatchSampler, t) = [sample(m.sampler, t) for _ in 1:m.n]

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -83,7 +83,7 @@ end
 
 function Base.take!(t::Trajectory)
     res = on_sample!(t.controler)
-    if isnothing(res)
+    if isnothing(res) && !isnothing(t.controler)
         nothing
     else
         sample(t.sampler, t.container)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -4,11 +4,11 @@ using Base.Threads
 
 
 """
-    Trajectory(container, sampler, controler)
+    Trajectory(container, sampler, controller)
 
 The `container` is used to store experiences. Common ones are [`Traces`](@ref)
 or [`Episodes`](@ref). The `sampler` is used to sample experience batches from
-the `container`. The `controler` controls whether it is time to sample a batch
+the `container`. The `controller` controls whether it is time to sample a batch
 or not.
 
 Supported methoes are:
@@ -21,35 +21,35 @@ Supported methoes are:
 Base.@kwdef struct Trajectory{C,S,T}
     container::C
     sampler::S
-    controler::T
+    controller::T
 
     Trajectory(c::C, s::S, t::T) where {C,S,T} = new{C,S,T}(c, s, t)
 
-    function Trajectory(container::C, sampler::S, controler::T) where {C,S,T<:AsyncInsertSampleRatioControler}
+    function Trajectory(container::C, sampler::S, controller::T) where {C,S,T<:AsyncInsertSampleRatioController}
         t = Threads.@spawn while true
-            for msg in controler.ch_in
+            for msg in controller.ch_in
                 if msg.f === Base.push! || msg.f === Base.append!
                     n_pre = length(container)
                     msg.f(container, msg.args...; msg.kw...)
                     n_post = length(container)
-                    controler.n_inserted += n_post - n_pre
+                    controller.n_inserted += n_post - n_pre
                 else
                     msg.f(container, msg.args...; msg.kw...)
                 end
 
-                if controler.n_inserted >= controler.threshold
-                    if controler.n_sampled <= (controler.n_inserted - controler.threshold) * controler.ratio
+                if controller.n_inserted >= controller.threshold
+                    if controller.n_sampled <= (controller.n_inserted - controller.threshold) * controller.ratio
                         batch = sample(sampler, container)
-                        put!(controler.ch_out, batch)
-                        controler.n_sampled += 1
+                        put!(controller.ch_out, batch)
+                        controller.n_sampled += 1
                     end
                 end
             end
         end
 
-        bind(controler.ch_in, t)
-        bind(controler.ch_out, t)
-        new{C,S,T}(container, sampler, controler)
+        bind(controller.ch_in, t)
+        bind(controller.ch_out, t)
+        new{C,S,T}(container, sampler, controller)
     end
 end
 
@@ -60,7 +60,7 @@ function Base.push!(t::Trajectory, x)
     n_pre = length(t.container)
     push!(t.container, x)
     n_post = length(t.container)
-    on_insert!(t.controler, n_post - n_pre)
+    on_insert!(t.controller, n_post - n_pre)
 end
 
 struct CallMsg
@@ -69,8 +69,8 @@ struct CallMsg
     kw::Any
 end
 
-Base.push!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioControler}, args...; kw...) = put!(t.controler.ch_in, CallMsg(Base.push!, args, kw))
-Base.append!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioControler}, args...; kw...) = put!(t.controler.ch_in, CallMsg(Base.append!, args, kw))
+Base.push!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}, args...; kw...) = put!(t.controller.ch_in, CallMsg(Base.push!, args, kw))
+Base.append!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}, args...; kw...) = put!(t.controller.ch_in, CallMsg(Base.append!, args, kw))
 
 Base.append!(t::Trajectory; kw...) = append!(t, values(kw))
 
@@ -78,12 +78,12 @@ function Base.append!(t::Trajectory, x)
     n_pre = length(t.container)
     append!(t.container, x)
     n_post = length(t.container)
-    on_insert!(t.controler, n_post - n_pre)
+    on_insert!(t.controller, n_post - n_pre)
 end
 
 function Base.take!(t::Trajectory)
-    res = on_sample!(t.controler)
-    if isnothing(res) && !isnothing(t.controler)
+    res = on_sample!(t.controller)
+    if isnothing(res) && !isnothing(t.controller)
         nothing
     else
         sample(t.sampler, t.container)
@@ -101,5 +101,5 @@ end
 
 Base.iterate(t::Trajectory, state) = iterate(t)
 
-Base.iterate(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioControler}, args...) = iterate(t.controler.ch_out, args...)
-Base.take!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioControler}) = take!(t.controler.ch_out)
+Base.iterate(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}, args...) = iterate(t.controller.ch_out, args...)
+Base.take!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}) = take!(t.controller.ch_out)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 @testset "Trajectories.jl" begin
     include("traces.jl")
     include("trajectories.jl")
+    include("samplers.jl")
 end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -1,0 +1,72 @@
+using Trajectories, Test
+
+@testset "MetaSampler" begin
+    t = Trajectory(
+        container=Traces(
+            a=Int[],
+            b=Bool[]
+        ),
+        sampler = MetaSampler(policy = BatchSampler(3), critic = BatchSampler(5)),
+        controler = InsertSampleControler(10, 0)
+    )
+
+    append!(t; a=[1, 2, 3, 4], b=[false, true, false, true])
+
+    batches = []
+
+    for batch in t
+        push!(batches, batch)
+    end
+
+    @test length(batches) == 10
+    @test length(batches[1][:policy][:a]) == 3 && length(batches[1][:critic][:b]) == 5    
+end
+
+@testset "MultiBatchSampler" begin
+    t = Trajectory(
+        container=Traces(
+            a=Int[],
+            b=Bool[]
+        ),
+        sampler = MetaSampler(policy = BatchSampler(3), critic = MultiBatchSampler(BatchSampler(5), 2)),
+        controler = InsertSampleControler(10, 0)
+    )
+
+    append!(t; a=[1, 2, 3, 4], b=[false, true, false, true])
+
+    batches = []
+
+    for batch in t
+        push!(batches, batch)
+    end
+
+    @test length(batches) == 10
+    @test length(batches[1][:policy][:a]) == 3 
+    @test length(batches[1][:critic]) == 2 # we sampled 2 batches for critic
+    @test length(batches[1][:critic][1][:b]) == 5 #each batch is 5 samples 
+end
+
+@testset "async trajectories" begin
+    threshould = 100
+    ratio = 1 / 4
+    t = Trajectory(
+        container=Traces(
+            a=Int[],
+            b=Bool[]
+        ),
+        sampler=BatchSampler(3),
+        controler=AsyncInsertSampleRatioControler(ratio, threshould)
+    )
+
+    n = 100
+    insert_task = @async for i in 1:n
+        append!(t; a=[i, i, i, i], b=[false, true, false, true])
+    end
+
+    s = 0
+    sample_task = @async for _ in t
+        s += 1
+    end
+    sleep(1)
+    @test s == (n - threshould * ratio) + 1
+end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -7,7 +7,7 @@ using Trajectories, Test
             b=Bool[]
         ),
         sampler = MetaSampler(policy = BatchSampler(3), critic = BatchSampler(5)),
-        controler = InsertSampleControler(10, 0)
+        controller = InsertSampleController(10, 0)
     )
 
     append!(t; a=[1, 2, 3, 4], b=[false, true, false, true])
@@ -29,7 +29,7 @@ end
             b=Bool[]
         ),
         sampler = MetaSampler(policy = BatchSampler(3), critic = MultiBatchSampler(BatchSampler(5), 2)),
-        controler = InsertSampleControler(10, 0)
+        controller = InsertSampleController(10, 0)
     )
 
     append!(t; a=[1, 2, 3, 4], b=[false, true, false, true])
@@ -55,7 +55,7 @@ end
             b=Bool[]
         ),
         sampler=BatchSampler(3),
-        controler=AsyncInsertSampleRatioControler(ratio, threshould)
+        controller=AsyncInsertSampleRatioController(ratio, threshould)
     )
 
     n = 100

--- a/test/trajectories.jl
+++ b/test/trajectories.jl
@@ -5,7 +5,7 @@
             b=Bool[]
         ),
         sampler=BatchSampler(3),
-        controler=InsertSampleRatioControler(0.25, 4)
+        controller=InsertSampleRatioController(0.25, 4)
     )
 
     batches = []
@@ -69,7 +69,7 @@ end
             b=Bool[]
         ),
         sampler=BatchSampler(3),
-        controler=AsyncInsertSampleRatioControler(ratio, threshould)
+        controller=AsyncInsertSampleRatioController(ratio, threshould)
     )
 
     n = 100


### PR DESCRIPTION
Hello,

Following the discussion in #13, I made this PR to add 3 things

- MetaSampler: a wrapper for a namedtuple of samplers. This allows to combine multiple samplers when needed in algorithm design. It returns a named tuple with the same keys as the wrapped one, and its values are sampled batches.
- MultiBatchSampler: a wrapper for a sampler that, when sampled, will sample n times instead of once. It thus returns a collection of n batches. This allows to combine samplers in a metasampler that are not meant to be sampled the same number of time. 
- InsertSampleController: it's an alternative to the ratio controller that will stop after a fixed number of samples. I first tried to implement the nothing controller you proposed in #13 but this lead to infinite sampling because the loop has no end condition. 
- I also fixed the spelling of controller (it has two L's apparently, full disclosure I just discovered that while writing this).

This should be enough to close #13 and will allow to easily refactor old algorithms using Trajectories.jl. 