### PR TITLE
Set default controller

### DIFF
--- a/src/controllers.jl
+++ b/src/controllers.jl
@@ -1,20 +1,18 @@
 export InsertSampleRatioController, InsertSampleController, AsyncInsertSampleRatioController
 
-mutable struct InsertSampleRatioController
-    ratio::Float64
-    threshold::Int
-    n_inserted::Int
-    n_sampled::Int
-end
-
 """
-    InsertSampleRatioController(ratio, threshold)
+    InsertSampleRatioController(;ratio=1., threshold=1)
 
 Used in [`Trajectory`](@ref). The `threshold` means the minimal number of
 insertings before sampling. The `ratio` balances the number of insertings and
 the number of samplings.
 """
-InsertSampleRatioController(ratio, threshold) = InsertSampleRatioController(ratio, threshold, 0, 0)
+Base.@kwdef mutable struct InsertSampleRatioController
+    ratio::Float64 = 1.0
+    threshold::Int = 1
+    n_inserted::Int = 0
+    n_sampled::Int = 0
+end
 
 function on_insert!(c::InsertSampleRatioController, n::Int)
     if n > 0
@@ -25,36 +23,6 @@ end
 function on_sample!(c::InsertSampleRatioController)
     if c.n_inserted >= c.threshold
         if c.n_sampled <= (c.n_inserted - c.threshold) * c.ratio
-            c.n_sampled += 1
-            true
-        end
-    end
-end
-
-"""
-    InsertSampleController(n, threshold)
-
-Used in [`Trajectory`](@ref). The `threshold` means the minimal number of
-insertings before sampling. The `n` is the number of samples until stopping.
-"""
-mutable struct InsertSampleController
-    n::Int
-    threshold::Int
-    n_inserted::Int
-    n_sampled::Int
-end
-
-InsertSampleController(n, threshold) = InsertSampleController(n, threshold, 0, 0)
-
-function on_insert!(c::InsertSampleController, n::Int)
-    if n > 0
-        c.n_inserted += n
-    end
-end
-
-function on_sample!(c::InsertSampleController)
-    if c.n_inserted >= c.threshold
-        if c.n_sampled < c.n
             c.n_sampled += 1
             true
         end

--- a/src/controllers.jl
+++ b/src/controllers.jl
@@ -1,4 +1,4 @@
-export InsertSampleRatioController, InsertSampleController, AsyncInsertSampleRatioController
+export InsertSampleRatioController, AsyncInsertSampleRatioController
 
 """
     InsertSampleRatioController(;ratio=1., threshold=1)

--- a/src/trajectory.jl
+++ b/src/trajectory.jl
@@ -23,7 +23,7 @@ Supported methoes are:
 Base.@kwdef struct Trajectory{C,S,T}
     container::C
     sampler::S
-    controller::T
+    controller::T = InsertSampleRatioController()
 
     Trajectory(c::C, s::S, t::T) where {C,S,T} = new{C,S,T}(c, s, t)
 
@@ -90,7 +90,7 @@ end
 
 function Base.take!(t::Trajectory)
     res = on_sample!(t.controller)
-    if isnothing(res) && !isnothing(t.controller)
+    if isnothing(res)
         nothing
     else
         sample(t.sampler, t.container)
@@ -110,3 +110,6 @@ Base.iterate(t::Trajectory, state) = iterate(t)
 
 Base.iterate(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}, args...) = iterate(t.controller.ch_out, args...)
 Base.take!(t::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}) = take!(t.controller.ch_out)
+
+Base.IteratorSize(::Trajectory{<:Any,<:Any,<:AsyncInsertSampleRatioController}) = Base.IsInfinite()
+Base.IteratorSize(::Trajectory) = Base.SizeUnknown()

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -35,7 +35,7 @@ end
 
     append!(t, (a=rand(Int, 10), b=rand(Bool, 10)))
 
-    batches = [x for x in t]
+    batches = collect(t)
 
     @test length(batches) == 10
     @test length(batches[1][:policy][:a]) == 3 && length(batches[1][:critic][:b]) == 5
@@ -52,7 +52,7 @@ end
 
     append!(t, (a=rand(Int, 10), b=rand(Bool, 10)))
 
-    batches = [x for x in t]
+    batches = collect(t)
 
     @test length(batches) == 10
     @test length(batches[1][:policy][:a]) == 3

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -31,16 +31,11 @@ end
             b=Bool[]
         ),
         sampler=MetaSampler(policy=BatchSampler(3), critic=BatchSampler(5)),
-        controller=InsertSampleController(10, 0)
     )
 
-    append!(t, (a=[1, 2, 3, 4], b=[false, true, false, true]))
+    append!(t, (a=rand(Int, 10), b=rand(Bool, 10)))
 
-    batches = []
-
-    for batch in t
-        push!(batches, batch)
-    end
+    batches = [x for x in t]
 
     @test length(batches) == 10
     @test length(batches[1][:policy][:a]) == 3 && length(batches[1][:critic][:b]) == 5
@@ -53,16 +48,11 @@ end
             b=Bool[]
         ),
         sampler=MetaSampler(policy=BatchSampler(3), critic=MultiBatchSampler(BatchSampler(5), 2)),
-        controller=InsertSampleController(10, 0)
     )
 
-    append!(t, (a=[1, 2, 3, 4], b=[false, true, false, true]))
+    append!(t, (a=rand(Int, 10), b=rand(Bool, 10)))
 
-    batches = []
-
-    for batch in t
-        push!(batches, batch)
-    end
+    batches = [x for x in t]
 
     @test length(batches) == 10
     @test length(batches[1][:policy][:a]) == 3

--- a/test/trajectories.jl
+++ b/test/trajectories.jl
@@ -6,11 +6,11 @@
         ),
         sampler=BatchSampler(3),
     )
-    batches = [x for x in t]
+    batches = collect(t)
     @test length(batches) == 0
 
     push!(t, (a=1, b=false))
-    batches = [x for x in t]
+    batches = collect(t)
     @test length(batches) == 1
 end
 

--- a/test/trajectories.jl
+++ b/test/trajectories.jl
@@ -1,3 +1,19 @@
+@testset "Default InsertSampleRatioController" begin
+    t = Trajectory(
+        container=Traces(
+            a=Int[],
+            b=Bool[]
+        ),
+        sampler=BatchSampler(3),
+    )
+    batches = [x for x in t]
+    @test length(batches) == 0
+
+    push!(t, (a=1, b=false))
+    batches = [x for x in t]
+    @test length(batches) == 1
+end
+
 @testset "trajectories" begin
     t = Trajectory(
         container=Traces(
@@ -5,7 +21,7 @@
             b=Bool[]
         ),
         sampler=BatchSampler(3),
-        controller=InsertSampleRatioController(0.25, 4)
+        controller=InsertSampleRatioController(ratio=0.25, threshold=4)
     )
 
     batches = []


### PR DESCRIPTION
- Set `InsertSampleRatioController` as the default controller in Trajectory.
- Add default parameters for `InsertSampleRatioController`
- Support list comprehension and `collect` on Trajectory


`InsertSampleController` is removed for now.

@HenriDeh If I understand it correctly, the original `InsertSampleController` is to control the total number of sampled batches. That seems like a very rare use case to me. After adding default parameters for `InsertSampleRatioController`, I think it is preferable, as you can see in the test cases. If you think it is still useful, I can add it back. But we'd better to rename it to `MaxSampleController` or something similar.