### PR TITLE
Change default value of `n_inserted` in `InsertSampleRatioController`

### DIFF
--- a/src/controllers.jl
+++ b/src/controllers.jl
@@ -10,7 +10,7 @@ the number of samplings.
 Base.@kwdef mutable struct InsertSampleRatioController
     ratio::Float64 = 1.0
     threshold::Int = 1
-    n_inserted::Int = 0
+    n_inserted::Int = -1
     n_sampled::Int = 0
 end
 


### PR DESCRIPTION
In RL.jl, the first step is to insert `(:state, :action)` values by default. This is just a partial inserting. So changing the default value from `0` to `-1` will make more sense here. In other cases, we can still set the value explicitly.