### PR TITLE
Move samples to Matrix

### DIFF
--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -49,7 +49,7 @@ sample(s::BatchSampler{names}, t::AbstractTraces) where {names} = sample(s, t, n
 
 function sample(s::BatchSampler, t::AbstractTraces, names)
     inds = rand(s.rng, 1:length(t), s.batch_size)
-    NamedTuple{names}(map(x -> Matrix(t[x][inds]), names))
+    NamedTuple{names}(map(x -> collect(t[x][inds]), names))
 end
 
 # !!! avoid iterating an empty trajectory
@@ -67,7 +67,7 @@ sample(s::BatchSampler{nothing}, t::CircularPrioritizedTraces) = sample(s, t, ke
 
 function sample(s::BatchSampler, t::CircularPrioritizedTraces, names)
     inds, priorities = rand(s.rng, t.priorities, s.batch_size)
-    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> Matrix(t.traces[x][inds]), names)...))
+    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[x][inds]), names)...))
 end
 
 #####
@@ -172,13 +172,13 @@ function sample(nbs::NStepBatchSampler, ts, ::Val{SS′ART}, inds)
         foldr(((rr, tt), init) -> rr + nbs.γ * init * (1 - tt), zip(r⃗, t⃗); init=0.0f0)
     end
 
-    NamedTuple{SS′ART}(map(Matrix, (s, s′, a, r, t)))
+    NamedTuple{SS′ART}(map(collect, (s, s′, a, r, t)))
 end
 
 function sample(s::NStepBatchSampler, ts, ::Val{SS′L′ART}, inds)
     s, s′, a, r, t = sample(s, ts, Val(SSART), inds)
     l = consecutive_view(ts[:next_legal_actions_mask], inds)
-    NamedTuple{SSLART}(map(Matrix, (s, s′, l, a, r, t)))
+    NamedTuple{SSLART}(map(collect, (s, s′, l, a, r, t)))
 end
 
 function sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces) where {names}

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -19,7 +19,7 @@ Just return the underlying traces.
 """
 struct DummySampler end
 
-(::DummySampler, t) = t
+sample(::DummySampler, t) = t
 
 #####
 # BatchSampler

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -178,7 +178,7 @@ end
 function sample(s::NStepBatchSampler, ts, ::Val{SS′L′ART}, inds)
     s, s′, a, r, t = sample(s, ts, Val(SSART), inds)
     l = consecutive_view(ts[:next_legal_actions_mask], inds)
-    NamedTuple{SSLART}((map(Matrix, (s, s′, l, a, r, t)))
+    NamedTuple{SSLART}(map(Matrix, (s, s′, l, a, r, t)))
 end
 
 function sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces) where {names}

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -19,7 +19,7 @@ Just return the underlying traces.
 """
 struct DummySampler end
 
-sample(::DummySampler, t) = t
+(::DummySampler, t) = t
 
 #####
 # BatchSampler
@@ -49,7 +49,7 @@ sample(s::BatchSampler{names}, t::AbstractTraces) where {names} = sample(s, t, n
 
 function sample(s::BatchSampler, t::AbstractTraces, names)
     inds = rand(s.rng, 1:length(t), s.batch_size)
-    NamedTuple{names}(map(x -> t[x][inds], names))
+    NamedTuple{names}(map(x -> Matrix(t[x][inds]), names))
 end
 
 # !!! avoid iterating an empty trajectory
@@ -67,7 +67,7 @@ sample(s::BatchSampler{nothing}, t::CircularPrioritizedTraces) = sample(s, t, ke
 
 function sample(s::BatchSampler, t::CircularPrioritizedTraces, names)
     inds, priorities = rand(s.rng, t.priorities, s.batch_size)
-    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> t.traces[x][inds], names)...))
+    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> Matrix(t.traces[x][inds]), names)...))
 end
 
 #####
@@ -172,13 +172,13 @@ function sample(nbs::NStepBatchSampler, ts, ::Val{SS′ART}, inds)
         foldr(((rr, tt), init) -> rr + nbs.γ * init * (1 - tt), zip(r⃗, t⃗); init=0.0f0)
     end
 
-    NamedTuple{SS′ART}((s, s′, a, r, t))
+    NamedTuple{SS′ART}(map(Matrix, (s, s′, a, r, t)))
 end
 
 function sample(s::NStepBatchSampler, ts, ::Val{SS′L′ART}, inds)
     s, s′, a, r, t = sample(s, ts, Val(SSART), inds)
     l = consecutive_view(ts[:next_legal_actions_mask], inds)
-    NamedTuple{SSLART}((s, s′, l, a, r, t))
+    NamedTuple{SSLART}((map(Matrix, (s, s′, l, a, r, t)))
 end
 
 function sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces) where {names}


### PR DESCRIPTION
The current implementation does not work with CUDA because it returns views, which will perform scalar indexing when passing a batch to a NN.  Moving a sampled batch to a Matrix not only avoids that but also speeds up the matrix multiplications during NN forward and backward passes.