### PR TITLE
push! performance tweaks

### DIFF
--- a/src/traces.jl
+++ b/src/traces.jl
@@ -351,7 +351,7 @@ for f in (:push!, :pushfirst!)
         end
     end
 
-    @eval function Base.$f(ts::Traces{names,T}, ::Val{k}, v) where {names,T,k}
+    @eval function Base.$f(ts::Traces, ::Val{k}, v) where {k}
         $f(ts.traces[ts.inds[k]], Val(k), v)
     end
 


### PR DESCRIPTION
This PR should speed up pushing to typical, multileveled `Trace` objects and reduces allocations, but comes at the cost of simple `Trace` object performance. @HenriDeh What do you think?

Running the `ReinforcementLearning.jl/src/ReinforcementLearningCore/test/core/core.jl` first example, 10% speed bump and 15% fewer allocations (by count)

```
After: 10.542 μs (133 allocations: 6.38 KiB)
Before: 11.666 μs (158 allocations: 6.95 KiB)
```

## Simple Performance Test 

```julia
using ReinforcementLearningTrajectories
using ReinforcementLearningTrajectories: AbstractTrace
using BenchmarkTools

t = Traces(;
a=[1, 2],
b=Bool[0, 1]
)

@btime push!(t, (; a=3, b=true))
# After: 283.039 ns (7 allocations: 224 bytes)
# Before: 184.911 ns (7 allocations: 192 bytes)

t = CircularArraySARTTraces(;
capacity=3,
state=Float32 => (2, 3),
action=Float32 => (2,),
reward=Float32 => (),
terminal=Bool => ()
)

@btime push!(t, ((state=ones(Float32, 2, 3), action=ones(Float32, 2))))
# After: 408.960 ns (10 allocations: 528 bytes)
# Before: 1.146 μs (22 allocations: 816 bytes)
```