### PR TITLE
Generalize NStepBatchSampler

### DIFF
--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -150,7 +150,7 @@ end
 
 export NStepBatchSampler
 
-mutable struct NStepBatchSampler{traces}
+struct NStepBatchSampler{traces}
     n::Int # !!! n starts from 1
     batch_size::Int
     stack_size::Int

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -180,10 +180,8 @@ function sample(sampler::NStepBatchSampler, trajectory, ::Val{SS′ART}, inds)
     t_horizon = trajectory[:terminal][[x + j for j in 0:sampler.n-1, x in inds]]
     r_horizon = trajectory[:reward][[x + j for j in 0:sampler.n-1, x in inds]]
 
-    @assert ndims(t_horizon) == 2
     t = any(t_horizon, dims=1) |> vec
 
-    @assert ndims(r_horizon) == 2
     r = map(eachcol(r_horizon), eachcol(t_horizon)) do r⃗, t⃗
         foldr(((rr, tt), init) -> rr + sampler.γ * init * (1 - tt), zip(r⃗, t⃗); init=0.0f0)
     end

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -180,8 +180,6 @@ function sample(sampler::NStepBatchSampler, trajectory, ::Val{SS′ART}, inds)
     t_horizon = trajectory[:terminal][[x + j for j in 0:sampler.n-1, x in inds]]
     r_horizon = trajectory[:reward][[x + j for j in 0:sampler.n-1, x in inds]]
 
-    t = any(t_horizon, dims=1) |> vec
-
     r = map(eachcol(r_horizon), eachcol(t_horizon)) do r⃗, t⃗
         foldr(((rr, tt), init) -> rr + sampler.γ * init * (1 - tt), zip(r⃗, t⃗); init=0.0f0)
     end


### PR DESCRIPTION
The current implementation of NStepBatchSampler is not general in the sense that it can be used with algorithms that do weighted importance sampling (vtrace and retrace for example). It really is only useful for algorithms that do a plain TD(n) update. But this is known to be biased and not really used anymore (or shouldn't be) now except for pedagogy and pure-online algorithms. 

The current behavior is 
1. sample a state, an action, the n following rewards, and the state n steps later. 
2. compute a discounted sum of rewards to act as a reward for a standard TD update.

This PR generalizes this for algorithms that need all the information of the n-steps (all states, all actions and all rewards).