### PR TITLE
Add append for RelativeTrace to MultiplexArrays 

### DIFF
--- a/src/traces.jl
+++ b/src/traces.jl
@@ -149,7 +149,7 @@ for f in (:push!, :pushfirst!, :append!, :prepend!)
         end
     end
     @eval function Base.$f(t::MultiplexTraces{names}, x::RelativeTrace{left, right}) where {names, left, right}
-        if right == 0 #do not accept appending the second name as it would be appended twice
+        if left == 0 #do not accept appending the second name as it would be appended twice
             $f(t[first(names)].trace, x.trace)
         end
     end

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -148,6 +148,13 @@ for f in (:push!, :pushfirst!, :append!, :prepend!)
             throw(ArgumentError("unknown trace name: $k"))
         end
     end
+    @eval function Base.$f(t::MultiplexTraces{names}, x::RelativeTrace{left, right}) where {names, left, right}
+        if right == 0
+            $f(t[first(names)].trace, x.trace)
+        else
+            $f(t[last(names)].trace, x.trace)
+        end
+    end
 end
 
 #####

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -149,10 +149,8 @@ for f in (:push!, :pushfirst!, :append!, :prepend!)
         end
     end
     @eval function Base.$f(t::MultiplexTraces{names}, x::RelativeTrace{left, right}) where {names, left, right}
-        if right == 0
+        if right == 0 #do not accept appending the second name as it would be appended twice
             $f(t[first(names)].trace, x.trace)
-        else
-            $f(t[last(names)].trace, x.trace)
         end
     end
 end

--- a/test/traces.jl
+++ b/test/traces.jl
@@ -57,6 +57,11 @@ end
     t[end] == (state=2, next_state=3)
     empty!(t)
     @test length(t) == 0
+
+    t2 = MultiplexTraces{(:state, :next_state)}(Int[1,2,3,4])
+    append!(t, t2[:state])
+    @test t[:state] == [1,2,3]
+    @test t[:next_state] == [2,3,4]
 end
 
 @testset "MergedTraces" begin


### PR DESCRIPTION
Currently, appending a Traces to a Traces fails if they contain a MultiplexTrace. This is because in the append code
```
    @eval function Base.$f(ts::Traces, xs::Traces)
        for k in keys(xs)
            t = ts.traces[ts.inds[k]]
            $f(t, xs[k])
        end
    end
``` 
where f is `:append!`, t is a `MultiplexTrace` and `xs[k]` is a RelativeTrace. Appending to a MutliplexTrace was only defined for a NamedTuple but this is not what is called in the loop above. This PR implements a second append that should only be called once by the above loop (avoiding appending twice, once :state and once :next_state). 