### PR TITLE
Fix interaction between CircularPrioritizedTraces and NStepBatchSampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReinforcementLearningTrajectories"
 uuid = "6486599b-a3cd-4e92-a99a-2cea90cc8c3c"
-version = "0.2"
+version = "0.2.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/common/CircularPrioritizedTraces.jl
+++ b/src/common/CircularPrioritizedTraces.jl
@@ -60,3 +60,5 @@ function Base.getindex(ts::CircularPrioritizedTraces, s::Symbol)
 end
 
 Base.getindex(t::CircularPrioritizedTraces{<:Any,names}, i) where {names} = NamedTuple{names}(map(k -> t[k][i], names))
+
+capacity(t::CircularPrioritizedTraces) = ReinforcementLearningTrajectories.capacity(t.traces)

--- a/src/episodes.jl
+++ b/src/episodes.jl
@@ -39,8 +39,21 @@ struct PartialNamedTuple{T}
     namedtuple::T
 end
 
+# Capacity of an EpisodesBuffer is the capacity of the underlying traces + 1 for certain cases
+function is_capacity_plus_one(traces::AbstractTraces)
+    if any(t->t isa MultiplexTraces, traces.traces)
+        # MultiplexTraces buffer next_state and next_action, so we need to add one to the capacity
+        return true
+    elseif traces isa CircularPrioritizedTraces
+        # CircularPrioritizedTraces buffer next_state and next_action, so we need to add one to the capacity
+        return true
+    else
+        false
+    end
+end
+
 function EpisodesBuffer(traces::AbstractTraces)
-    cap = any(t->t isa MultiplexTraces, traces.traces) ? capacity(traces) + 1 : capacity(traces)
+    cap = is_capacity_plus_one(traces) ? capacity(traces) + 1 : capacity(traces)
     @assert isempty(traces) "EpisodesBuffer must be initialized with empty traces."
     if !isinf(cap)
         legalinds =  CircularBuffer{Bool}(cap)

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -184,7 +184,7 @@ function StatsBase.sample(nbs::NStepBatchSampler, ts, ::Val{SS′ART}, inds)
         s = ts[:state][inds]
         s′ = ts[:next_state][inds.+(nbs.n-1)]
     else
-        s = ts[:state][[x + i + 1 for i in -nbs.stack_size+1:0, x in inds]]
+        s = ts[:state][[x + i for i in -nbs.stack_size+1:0, x in inds]]
         s′ = ts[:next_state][[x + nbs.n - 1 + i for i in -nbs.stack_size+1:0, x in inds]]
     end
 
@@ -214,15 +214,6 @@ function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, 
     st = deepcopy(t.priorities)
     st .*= e.sampleable_inds[1:end-1] #temporary sumtree that puts 0 priority to non sampleable indices.
     inds, priorities = rand(s.rng, st, s.batch_size)
-
-    merge(
-        (key=t.keys[inds], priority=priorities),
-        StatsBase.sample(s, t.traces, Val(names), inds)
-    )
-end
-
-function StatsBase.sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces) where {names}
-    inds, priorities = rand(s.rng, t.priorities, s.batch_size)
 
     merge(
         (key=t.keys[inds], priority=priorities),

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -230,7 +230,7 @@ function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, 
     )
 end
 
-function StatsBase.sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces}) where {names}
+function StatsBase.sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces) where {names}
     inds, priorities = rand(s.rng, t.priorities, s.batch_size)
 
     merge(

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -229,3 +229,12 @@ function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, 
         StatsBase.sample(s, t.traces, Val(names), inds)
     )
 end
+
+function StatsBase.sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces}) where {names}
+    inds, priorities = rand(s.rng, t.priorities, s.batch_size)
+
+    merge(
+        (key=t.keys[inds], priority=priorities),
+        StatsBase.sample(s, t.traces, Val(names), inds)
+    )
+end

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -209,15 +209,6 @@ function StatsBase.sample(s::NStepBatchSampler, ts, ::Val{SS′L′ART}, inds)
     NamedTuple{SSLART}(map(collect, (s, s′, l, a, r, t)))
 end
 
-function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, <:Any, <:CircularPrioritizedTraces})
-    t = e.traces
-    st = deepcopy(t.priorities)
-    st .*= e.sampleable_inds[1:end-1] #temporary sumtree that puts 0 priority to non sampleable indices.
-    inds, priorities = rand(s.rng, st, s.batch_size)
-
-    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[x][inds]), names)...))
-end
-
 function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, <:Any, <:CircularPrioritizedTraces}) where {names}
     t = e.traces
     st = deepcopy(t.priorities)

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -184,7 +184,7 @@ function StatsBase.sample(nbs::NStepBatchSampler, ts, ::Val{SS′ART}, inds)
         s = ts[:state][inds]
         s′ = ts[:next_state][inds.+(nbs.n-1)]
     else
-        s = ts[:state][[x + i for i in -nbs.stack_size+1:0, x in inds]]
+        s = ts[:state][[x + i + 1 for i in -nbs.stack_size+1:0, x in inds]]
         s′ = ts[:next_state][[x + nbs.n - 1 + i for i in -nbs.stack_size+1:0, x in inds]]
     end
 

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -209,8 +209,21 @@ function StatsBase.sample(s::NStepBatchSampler, ts, ::Val{SS′L′ART}, inds)
     NamedTuple{SSLART}(map(collect, (s, s′, l, a, r, t)))
 end
 
-function StatsBase.sample(s::NStepBatchSampler{names}, t::CircularPrioritizedTraces) where {names}
-    inds, priorities = rand(s.rng, t.priorities, s.batch_size)
+function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, <:Any, <:CircularPrioritizedTraces})
+    t = e.traces
+    st = deepcopy(t.priorities)
+    st .*= e.sampleable_inds[1:end-1] #temporary sumtree that puts 0 priority to non sampleable indices.
+    inds, priorities = rand(s.rng, st, s.batch_size)
+
+    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[x][inds]), names)...))
+end
+
+function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, <:Any, <:CircularPrioritizedTraces}) where {names}
+    t = e.traces
+    st = deepcopy(t.priorities)
+    st .*= e.sampleable_inds[1:end-1] #temporary sumtree that puts 0 priority to non sampleable indices.
+    inds, priorities = rand(s.rng, st, s.batch_size)
+
     merge(
         (key=t.keys[inds], priority=priorities),
         StatsBase.sample(s, t.traces, Val(names), inds)

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -135,5 +135,29 @@ end
     @test xs3.reward[1] ≈ 3 + γ * 4  # terminated at step 4
     @test xs3.reward[2] ≈ 5 + γ * (6 + γ * 7)
     @test xs3.reward[3] ≈ 7 + γ * (8 + γ * 9)
+
+    @testset "CircularPrioritizedTraces with NStepBatchSampler" begin
+        γ = 0.9
+        n_stack = 2
+        n_horizon = 3
+        batch_size = 4
+    
+        t = CircularPrioritizedTraces(
+            CircularArraySARTSATraces(;
+                capacity=10
+            ),
+            default_priority=1.0f0
+        )
+        s = NStepBatchSampler(n=n_horizon, γ=γ, stack_size=n_stack, batch_size=batch_size)
+        push!(t, (state = 1, action = true))
+        for i = 1:9
+            push!(t, (state = i+1, action = true, reward = i, terminal = false))
+        end
+    
+        xs = RLTrajectories.StatsBase.sample(s, t)
+        @test haskey(xs, :state)
+        @test haskey(xs, :priority)
+        @test haskey(xs, :key)
+    end    
 end
 #! format: on

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -135,30 +135,6 @@ end
     @test xs3.reward[1] ≈ 3 + γ * 4  # terminated at step 4
     @test xs3.reward[2] ≈ 5 + γ * (6 + γ * 7)
     @test xs3.reward[3] ≈ 7 + γ * (8 + γ * 9)
-
-    @testset "CircularPrioritizedTraces with NStepBatchSampler" begin
-        γ = 0.9
-        n_stack = 2
-        n_horizon = 3
-        batch_size = 4
-    
-        t = CircularPrioritizedTraces(
-            CircularArraySARTSATraces(;
-                capacity=10
-            ),
-            default_priority=1.0f0
-        )
-        s = NStepBatchSampler(n=n_horizon, γ=γ, stack_size=n_stack, batch_size=batch_size)
-        push!(t, (state = 1, action = true))
-        for i = 1:9
-            push!(t, (state = i+1, action = true, reward = i, terminal = false))
-        end
-    
-        xs = RLTrajectories.StatsBase.sample(s, t)
-        @test haskey(xs, :state)
-        @test haskey(xs, :priority)
-        @test haskey(xs, :key)
-    end    
 end
 #! format: on
 

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -161,3 +161,35 @@ end
     end    
 end
 #! format: on
+
+@testset "Trajectory with CircularArraySARTSTraces and NStepBatchSampler" begin
+    n=1
+    γ=0.99f0
+
+    t = Trajectory(
+        container=CircularPrioritizedTraces(
+            CircularArraySARTSTraces(
+                capacity=1000,
+                state=Float32 => (4,),
+            );
+            default_priority=100.0f0
+        ),
+        sampler=NStepBatchSampler{SS′ART}(
+            n=n,
+            γ=γ,
+            batch_size=32,
+        ),
+        controller=InsertSampleRatioController(
+            threshold=100,
+            n_inserted=-1
+        )
+    )
+
+    push!(t, (state = 1, action = true))
+    for i = 1:9
+        push!(t, (state = i+1, action = true, reward = i, terminal = false))
+    end
+
+    b = RLTrajectories.StatsBase.sample(t)
+    @test haskey(b, :priority)
+end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -145,7 +145,7 @@ end
     t = Trajectory(
         container=CircularPrioritizedTraces(
             CircularArraySARTSTraces(
-                capacity=1000,
+                capacity=5,
                 state=Float32 => (4,),
             );
             default_priority=100.0f0


### PR DESCRIPTION
- Fixes issue where dispatch on Circular Trajectories was not working for certain samplers, this I believe has been causing CI for https://github.com/JuliaReinforcementLearning/ReinforcementLearning.jl/pull/921 to fail as type dispatch fails to match :priority and :key keys