### PR TITLE
Use metaprogramming to improve type stability...

### DIFF
--- a/src/episodes.jl
+++ b/src/episodes.jl
@@ -98,7 +98,7 @@ pad!(vect::Vector{T}) where {T} = push!(vect, zero(T))
     i = 1
     ex = :()
     for tr in Trs.parameters
-        if (tr <: Trace)
+        if !(tr <: MultiplexTraces)
             #push a duplicate of last element as a dummy element, should never be sampled.
             ex = :($ex; pad!(trace_tuple.traces[$i]))
         end

--- a/src/episodes.jl
+++ b/src/episodes.jl
@@ -107,7 +107,14 @@ pad!(vect::Vector{T}) where {T} = push!(vect, zero(T))
     return :($ex)
 end
 
-fill_multiplex(es::EpisodesBuffer) = fill_multiplex(es.traces)
+# This function is currently unoptimized, could be optimized by using a generated function.
+function fill_multiplex(es::EpisodesBuffer)
+    for trace in es.traces.traces
+        if !(trace isa MultiplexTraces)
+            push!(trace, last(trace)) #push a duplicate of last element as a dummy element, should never be sampled.
+        end
+    end
+end
 
 fill_multiplex(es::EpisodesBuffer{<:Any,<:Any,<:CircularPrioritizedTraces}) = fill_multiplex(es.traces.traces)
 

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -49,7 +49,7 @@ StatsBase.sample(s::BatchSampler{names}, t::AbstractTraces) where {names} = Stat
 
 function StatsBase.sample(s::BatchSampler, t::AbstractTraces, names, weights = StatsBase.UnitWeights{Int}(length(t)))
     inds = StatsBase.sample(s.rng, 1:length(t), weights, s.batch_size)
-    NamedTuple{names}(map(x -> collect(t[x][inds]), names))
+    NamedTuple{names}(map(x -> collect(t[Val(x)][inds]), names))
 end
 
 function StatsBase.sample(s::BatchSampler, t::EpisodesBuffer, names)
@@ -74,12 +74,12 @@ function StatsBase.sample(s::BatchSampler, e::EpisodesBuffer{<:Any, <:Any, <:Cir
     st = deepcopy(t.priorities)
     st .*= e.sampleable_inds[1:end-1] #temporary sumtree that puts 0 priority to non sampleable indices.
     inds, priorities = rand(s.rng, st, s.batch_size)
-    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[x][inds]), names)...))
+    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[Val(x)][inds]), names)...))
 end
 
 function StatsBase.sample(s::BatchSampler, t::CircularPrioritizedTraces, names)
     inds, priorities = rand(s.rng, t.priorities, s.batch_size)
-    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[x][inds]), names)...))
+    NamedTuple{(:key, :priority, names...)}((t.keys[inds], priorities, map(x -> collect(t.traces[Val(x)][inds]), names)...))
 end
 
 #####

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -250,7 +250,10 @@ function Base.:(+)(t1::Traces{k1,T1,N1,E1}, t2::Traces{k2,T2,N2,E2}) where {k1,T
 end
 
 Base.size(t::Traces) = (mapreduce(length, min, t.traces),)
-capacity(t::Traces) = minimum(map(idx->capacity(t.traces[idx]),t.inds))
+
+function capacity(t::Traces{names,Trs,N,E}) where {names,Trs,N,E}
+    minimum(map(idx->capacity(t[idx]), names))
+end
 
 @generated function Base.push!(ts::Traces, xs::NamedTuple{N,T}) where {N,T}
     ex = :()
@@ -318,7 +321,7 @@ end
 for f in (:append!, :prepend!)
     @eval function Base.$f(ts::Traces, xs::Traces)
         for k in keys(xs)
-            t = ts.traces[ts.inds[k]]
+            t = _gettrace(ts, Val(k))
             $f(t, xs[k])
         end
     end

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -190,7 +190,7 @@ function Base.getindex(ts::Traces, ::Val{s}) where {s}
     if t isa AbstractTrace
         t
     elseif t isa MultiplexTraces
-        t[s]
+        _getindex(t, Val(s))
     else
         throw(ArgumentError("unknown trace name: $s"))
     end
@@ -215,7 +215,7 @@ end
 @generated function Base.getindex(t::Traces{names}, i) where {names}
     ex = :(NamedTuple{$(names)}($(Expr(:tuple))))
     for k in names
-        push!(ex.args[2].args, :(t[$(QuoteNode(k))][i]))
+        push!(ex.args[2].args, :(t[Val($(QuoteNode(k)))][i]))
     end
     return ex
 end

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -227,7 +227,7 @@ for f in (:push!, :pushfirst!)
     @eval @generated function Base.$f(ts::Traces, xs::NamedTuple{N,T}) where {N,T}
         ex = :()
         for n in N
-            ex = :($ex; push!(ts, Val($(QuoteNode(n))), xs.$n))
+            ex = :($ex; $f(ts, Val($(QuoteNode(n))), xs.$n))
         end
         return :($ex)
     end
@@ -241,7 +241,7 @@ for f in (:push!, :pushfirst!)
     end
 
     @eval function Base.$f(t::Trace, ::Val{k}, v) where {k}
-        $f(t, v)
+        $f(t.parent, v)
     end
 
     @eval function Base.$f(ts::MultiplexTraces, ::Val{k}, v) where {k}

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -223,14 +223,23 @@ end
 Base.size(t::Traces) = (mapreduce(length, min, t.traces),)
 capacity(t::Traces) = minimum(map(idx->capacity(t.traces[idx]),t.inds))
 
-for f in (:push!, :pushfirst!)
-    @eval @generated function Base.$f(ts::Traces, xs::NamedTuple{N,T}) where {N,T}
-        ex = :()
-        for n in N
-            ex = :($ex; $f(ts, Val($(QuoteNode(n))), xs.$n))
-        end
-        return :($ex)
+@eval @generated function Base.push!(ts::Traces, xs::NamedTuple{N,T}) where {N,T}
+    ex = :()
+    for n in N
+        ex = :($ex; push!(ts, Val($(QuoteNode(n))), xs.$n))
     end
+    return :($ex)
+end
+
+@eval @generated function Base.pushfirst!(ts::Traces, xs::NamedTuple{N,T}) where {N,T}
+    ex = :()
+    for n in N
+        ex = :($ex; pushfirst!(ts, Val($(QuoteNode(n))), xs.$n))
+    end
+    return :($ex)
+end
+
+for f in (:push!, :pushfirst!)
 
     @eval function Base.$f(ts::Traces, ::Val{k}, v) where {k}
         $f(ts.traces[ts.inds[k]], Val(k), v)

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -224,10 +224,12 @@ Base.size(t::Traces) = (mapreduce(length, min, t.traces),)
 capacity(t::Traces) = minimum(map(idx->capacity(t.traces[idx]),t.inds))
 
 for f in (:push!, :pushfirst!)
-    @eval function Base.$f(ts::Traces, xs::NamedTuple)
-        for (k, v) in pairs(xs)
-            $f(ts, Val(k), v)
+    @eval @generated function Base.$f(ts::Traces, xs::NamedTuple{N,T}) where {N,T}
+        ex = :()
+        for n in N
+            ex = :($ex; push!(ts, Val($(QuoteNode(n))), xs.$n))
         end
+        return :($ex)
     end
 
     @eval function Base.$f(ts::Traces, ::Val{k}, v) where {k}

--- a/test/episodes.jl
+++ b/test/episodes.jl
@@ -28,7 +28,7 @@ using Test
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
         @test eb.sampleable_inds == [1,1,1,1,1,0,0]
-        @test eb[6][:reward] == 5 #6 is not a valid index, the reward there is dummy duplicate of previous (5)
+        @test eb[6][:reward] == 0 #6 is not a valid index, the reward there is filled as zero
         ep2_len = 0
         for (j,i) = enumerate(8:11)
             ep2_len += 1
@@ -113,7 +113,7 @@ using Test
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
         @test eb.sampleable_inds == [1,1,1,1,1,0,0]
-        @test eb[6][:reward] == 5 #6 is not a valid index, the reward there is dummy duplicate of previous (5)
+        @test eb[6][:reward] == 0 #6 is not a valid index, the reward there is dummy, filled as zero
         ep2_len = 0
         for (j,i) = enumerate(8:11)
             ep2_len += 1

--- a/test/traces.jl
+++ b/test/traces.jl
@@ -115,3 +115,40 @@ end
     t8_view.a[1] = 0
     @test t8[:a][2] == 0
 end
+
+using ReinforcementLearningTrajectories: build_trace_index
+
+@testset "build_trace_index" begin
+    t1 = CircularArraySARTSATraces(;
+        capacity=3,
+        state=Float32 => (2, 3),
+        action=Float32 => (2,),
+        reward=Float32 => (),
+        terminal=Bool => ()
+    )
+    @test build_trace_index(typeof(t1).parameters[1], typeof(t1).parameters[2]) == Dict(:reward => 3,
+        :next_state => 1,
+        :state => 1,
+        :action => 2,
+        :next_action => 2,
+        :terminal => 4)
+
+    t2 = Traces(; a=[2, 3], b=[false, true])
+    build_trace_index(typeof(t2).parameters[1], typeof(t2).parameters[2])
+end
+
+@testset "push!(ts::Traces{names,Trs,N,E}, ::Val{k}, v)" begin
+    t1 = CircularArraySARTSATraces(;
+        capacity=3,
+        state=Float32 => (2, 3),
+        action=Float32 => (2,),
+        reward=Float32 => (),
+        terminal=Bool => ()
+    )
+    push!(t1, Val(:reward), 5)
+    @test t1[:reward][1] == 5
+
+    t2 = Traces(; a=[2, 3], b=[false, true])
+    push!(t2, Val(:a), 5)
+    @test t2[:a][3] == 5
+end

--- a/test/traces.jl
+++ b/test/traces.jl
@@ -148,7 +148,14 @@ end
     push!(t1, Val(:reward), 5)
     @test t1[:reward][1] == 5
 
+    @test size(Base.getindex(t1, :reward)) == (1,)
+    @test size(Base.getindex(t1, 1).state) == (2,3)
+
+
     t2 = Traces(; a=[2, 3], b=[false, true])
     push!(t2, Val(:a), 5)
     @test t2[:a][3] == 5
+
+    @test size(Base.getindex(t2, :a)) == (3,)
+    @test Base.getindex(t2, 1) == (; a = 2, b= false)
 end


### PR DESCRIPTION
Finally go around to coming up with a solution for type instability around pushing to trajectories. Essentially, because we know a bunch about what trajectory elements exist based on the type signature, we can skip doing things at runtime. This comes at a cost of code readability, but the performance improvements are striking...