### PR TITLE
add episodessampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReinforcementLearningTrajectories"
 uuid = "6486599b-a3cd-4e92-a99a-2cea90cc8c3c"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ julia> for batch in t
 - `BatchSampler`
 - `MetaSampler`
 - `MultiBatchSampler`
+- `EpisodesSampler`
 
 **Controllers**
 

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -262,9 +262,13 @@ function StatsBase.sample(::EpisodesSampler, t::EpisodesBuffer, names)
     ranges = UnitRange{Int}[]
     idx = 1
     while idx < length(t)
-        last_state_idx = idx + t.episodes_lengths[idx] - t.step_numbers[idx] + 1
-        push!(ranges,idx:last_state_idx)
-        idx = last_state_idx + 1
+        if t.sampleable_inds[idx] == 1
+            last_state_idx = idx + t.episodes_lengths[idx] - t.step_numbers[idx] + 1
+            push!(ranges,idx:last_state_idx)
+            idx = last_state_idx + 1
+        else
+            idx += 1
+        end
     end
     
     return [Episode(NamedTuple{names}(map(x -> collect(t[Val(x)][r]), names))) for r in ranges]

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -1,4 +1,5 @@
 using Random
+export EpisodesSampler, Episode, BatchSampler, NStepBatchSampler, MetaSampler, MultiBatchSampler, DummySampler
 
 struct SampleGenerator{S,T}
     sampler::S
@@ -232,4 +233,39 @@ function StatsBase.sample(s::NStepBatchSampler{names}, e::EpisodesBuffer{<:Any, 
         (key=t.keys[inds], priority=priorities),
         StatsBase.sample(s, t.traces, Val(names), inds)
     )
+end
+
+"""
+    EpisodesSampler()
+
+A sampler that samples all Episodes present in the Trajectory and divides them into 
+Episode containers. Truncated Episodes (e.g. due to the buffer capacity) are sampled as well.
+There will be at most one truncated episode and it will always be the first one. 
+"""
+struct EpisodesSampler{names}
+end
+
+EpisodesSampler() = EpisodesSampler{nothing}()
+#EpisodesSampler{names}() = new{names}()
+
+
+struct Episode{names, N <: NamedTuple{names}}
+    nt::N
+end
+
+@forward Episode.nt Base.keys, Base.haskey, Base.getindex
+
+StatsBase.sample(s::EpisodesSampler{nothing}, t::EpisodesBuffer) = StatsBase.sample(s,t,keys(t))
+StatsBase.sample(s::EpisodesSampler{names}, t::EpisodesBuffer) where names = StatsBase.sample(s,t,names)
+
+function StatsBase.sample(::EpisodesSampler, t::EpisodesBuffer, names)
+    ranges = UnitRange{Int}[]
+    idx = 1
+    while idx < length(t)
+        last_state_idx = idx + t.episodes_lengths[idx] - t.step_numbers[idx] + 1
+        push!(ranges,idx:last_state_idx)
+        idx = last_state_idx + 1
+    end
+    
+    return [Episode(NamedTuple{names}(map(x -> collect(t[Val(x)][r]), names))) for r in ranges]
 end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -1,4 +1,4 @@
-#@testset "Samplers" begin
+@testset "Samplers" begin
     @testset "BatchSampler" begin
         sz = 32
         s = BatchSampler(sz)
@@ -202,7 +202,7 @@
         @test sum(b.action .== 0) == 0
     end
 
-    #@testset "EpisodesSampler" begin
+    @testset "EpisodesSampler" begin
         s = EpisodesSampler()
         eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
         push!(eb, (state = 1, action = 1))

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -1,202 +1,240 @@
-@testset "BatchSampler" begin
-    sz = 32
-    s = BatchSampler(sz)
-    t = Traces(
-        state=rand(3, 4, 5),
-        action=rand(1:4, 5),
-    )
-
-    b = sample(s, t)
-
-    @test keys(b) == (:state, :action)
-    @test size(b.state) == (3, 4, sz)
-    @test size(b.action) == (sz,)
-    
-    #In EpisodesBuffer
-    eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
-    push!(eb, (state = 1, action = 1))
-    for i = 1:5
-        push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))
-    end
-    push!(eb, (state = 7, action = 7))
-    for (j,i) = enumerate(8:11)
-        push!(eb, (state = i, action =i, reward = i-1, terminal = false))
-    end
-    s = BatchSampler(1000)
-    b = sample(s, eb)
-    cm = counter(b[:state])
-    @test !haskey(cm, 6)
-    @test !haskey(cm, 11)
-    @test all(in(keys(cm)), [1:5;7:10])
-end
-
-@testset "MetaSampler" begin
-    t = Trajectory(
-        container=Traces(
-            a=Int[],
-            b=Bool[]
-        ),
-        sampler=MetaSampler(policy=BatchSampler(3), critic=BatchSampler(5)),
-    )
-    push!(t, (a = 1,))
-    for i in 1:10
-        push!(t, (a=i, b=true))
-    end
-
-    batches = collect(t)
-
-    @test length(batches) == 11
-    @test length(batches[1][:policy][:a]) == 3 && length(batches[1][:critic][:b]) == 5
-end
-
-@testset "MultiBatchSampler" begin
-    t = Trajectory(
-        container=Traces(
-            a=Int[],
-            b=Bool[]
-        ),
-        sampler=MetaSampler(policy=BatchSampler(3), critic=MultiBatchSampler(BatchSampler(5), 2)),
-    )
-
-    push!(t, (a = 1,))
-    for i in 1:10
-        push!(t, (a=i, b=true))
-    end
-
-    batches = collect(t)
-
-    @test length(batches) == 11
-    @test length(batches[1][:policy][:a]) == 3
-    @test length(batches[1][:critic]) == 2 # we sampled 2 batches for critic
-    @test length(batches[1][:critic][1][:b]) == 5 #each batch is 5 samples 
-end
-
-#! format: off
-@testset "NStepSampler" begin
-    γ = 0.9
-    n_stack = 2
-    n_horizon = 3
-    batch_size = 4
-
-    t1 = MultiplexTraces{(:state, :next_state)}(1:10) +
-        MultiplexTraces{(:action, :next_action)}(iseven.(1:10)) +
-        Traces(
-            reward=1:9,
-            terminal=Bool[0, 0, 0, 1, 0, 0, 0, 0, 1],
+#@testset "Samplers" begin
+    @testset "BatchSampler" begin
+        sz = 32
+        s = BatchSampler(sz)
+        t = Traces(
+            state=rand(3, 4, 5),
+            action=rand(1:4, 5),
         )
 
-    s1 = NStepBatchSampler(n=n_horizon, γ=γ, stack_size=n_stack, batch_size=batch_size)
+        b = sample(s, t)
 
-    xs = RLTrajectories.StatsBase.sample(s1, t1)
-
-    @test size(xs.state) == (n_stack, batch_size)
-    @test size(xs.next_state) == (n_stack, batch_size)
-    @test size(xs.action) == (batch_size,)
-    @test size(xs.reward) == (batch_size,)
-    @test size(xs.terminal) == (batch_size,)
-
-    
-    state_size = (2,3)
-    n_state = reduce(*, state_size)
-    total_length = 10
-    t2 = MultiplexTraces{(:state, :next_state)}(
-            reshape(1:n_state * total_length, state_size..., total_length)
-        ) +
-        MultiplexTraces{(:action, :next_action)}(iseven.(1:total_length)) +
-        Traces(
-            reward=1:total_length-1,
-            terminal=Bool[0, 0, 0, 1, 0, 0, 0, 0, 1],
-        )
-
-    xs2 = RLTrajectories.StatsBase.sample(s1, t2)
-
-    @test size(xs2.state) == (state_size..., n_stack, batch_size)
-    @test size(xs2.next_state) == (state_size..., n_stack, batch_size)
-    @test size(xs2.action) == (batch_size,)
-    @test size(xs2.reward) == (batch_size,)
-    @test size(xs2.terminal) == (batch_size,)
-
-    inds = [3, 5, 7]
-    xs3 = RLTrajectories.StatsBase.sample(s1, t2, Val(SS′ART), inds)
-
-    @test xs3.state == cat(
-        (
-            reshape(n_state * (i-n_stack)+1: n_state * i, state_size..., n_stack)
-            for i in inds
-        )...
-        ;dims=length(state_size) + 2
-    ) 
-
-    @test xs3.next_state == xs3.state .+ (n_state * n_horizon)
-    @test xs3.action == iseven.(inds)
-    @test xs3.terminal == [any(t2[:terminal][i: i+n_horizon-1]) for i in inds]
-
-    # manual calculation
-    @test xs3.reward[1] ≈ 3 + γ * 4  # terminated at step 4
-    @test xs3.reward[2] ≈ 5 + γ * (6 + γ * 7)
-    @test xs3.reward[3] ≈ 7 + γ * (8 + γ * 9)
-end
-#! format: on
-
-@testset "Trajectory with CircularPrioritizedTraces and NStepBatchSampler" begin
-    n=1
-    γ=0.99f0
-
-    t = Trajectory(
-        container=CircularPrioritizedTraces(
-            CircularArraySARTSTraces(
-                capacity=5,
-                state=Float32 => (4,),
-            );
-            default_priority=100.0f0
-        ),
-        sampler=NStepBatchSampler{SS′ART}(
-            n=n,
-            γ=γ,
-            batch_size=32,
-        ),
-        controller=InsertSampleRatioController(
-            threshold=100,
-            n_inserted=-1
-        )
-    )
-
-    push!(t, (state = 1, action = true))
-    for i = 1:9
-        push!(t, (state = i+1, action = true, reward = i, terminal = false))
+        @test keys(b) == (:state, :action)
+        @test size(b.state) == (3, 4, sz)
+        @test size(b.action) == (sz,)
+        
+        #In EpisodesBuffer
+        eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
+        push!(eb, (state = 1, action = 1))
+        for i = 1:5
+            push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))
+        end
+        push!(eb, (state = 7, action = 7))
+        for (j,i) = enumerate(8:11)
+            push!(eb, (state = i, action =i, reward = i-1, terminal = false))
+        end
+        s = BatchSampler(1000)
+        b = sample(s, eb)
+        cm = counter(b[:state])
+        @test !haskey(cm, 6)
+        @test !haskey(cm, 11)
+        @test all(in(keys(cm)), [1:5;7:10])
     end
 
-    b = RLTrajectories.StatsBase.sample(t)
-    @test haskey(b, :priority)
-    @test sum(b.action .== 0) == 0
-end
-
-
-@testset "Trajectory with CircularArraySARTSTraces and NStepBatchSampler" begin
-    n=1
-    γ=0.99f0
-
-    t = Trajectory(
-        container=CircularArraySARTSTraces(
-                capacity=5,
-                state=Float32 => (4,),
-        ),
-        sampler=NStepBatchSampler{SS′ART}(
-            n=n,
-            γ=γ,
-            batch_size=32,
-        ),
-        controller=InsertSampleRatioController(
-            threshold=100,
-            n_inserted=-1
+    @testset "MetaSampler" begin
+        t = Trajectory(
+            container=Traces(
+                a=Int[],
+                b=Bool[]
+            ),
+            sampler=MetaSampler(policy=BatchSampler(3), critic=BatchSampler(5)),
         )
-    )
+        push!(t, (a = 1,))
+        for i in 1:10
+            push!(t, (a=i, b=true))
+        end
 
-    push!(t, (state = 1, action = true))
-    for i = 1:9
-        push!(t, (state = i+1, action = true, reward = i, terminal = false))
+        batches = collect(t)
+
+        @test length(batches) == 11
+        @test length(batches[1][:policy][:a]) == 3 && length(batches[1][:critic][:b]) == 5
     end
 
-    b = RLTrajectories.StatsBase.sample(t)
-    @test sum(b.action .== 0) == 0
+    @testset "MultiBatchSampler" begin
+        t = Trajectory(
+            container=Traces(
+                a=Int[],
+                b=Bool[]
+            ),
+            sampler=MetaSampler(policy=BatchSampler(3), critic=MultiBatchSampler(BatchSampler(5), 2)),
+        )
+
+        push!(t, (a = 1,))
+        for i in 1:10
+            push!(t, (a=i, b=true))
+        end
+
+        batches = collect(t)
+
+        @test length(batches) == 11
+        @test length(batches[1][:policy][:a]) == 3
+        @test length(batches[1][:critic]) == 2 # we sampled 2 batches for critic
+        @test length(batches[1][:critic][1][:b]) == 5 #each batch is 5 samples 
+    end
+
+    #! format: off
+    @testset "NStepSampler" begin
+        γ = 0.9
+        n_stack = 2
+        n_horizon = 3
+        batch_size = 4
+
+        t1 = MultiplexTraces{(:state, :next_state)}(1:10) +
+            MultiplexTraces{(:action, :next_action)}(iseven.(1:10)) +
+            Traces(
+                reward=1:9,
+                terminal=Bool[0, 0, 0, 1, 0, 0, 0, 0, 1],
+            )
+
+        s1 = NStepBatchSampler(n=n_horizon, γ=γ, stack_size=n_stack, batch_size=batch_size)
+
+        xs = RLTrajectories.StatsBase.sample(s1, t1)
+
+        @test size(xs.state) == (n_stack, batch_size)
+        @test size(xs.next_state) == (n_stack, batch_size)
+        @test size(xs.action) == (batch_size,)
+        @test size(xs.reward) == (batch_size,)
+        @test size(xs.terminal) == (batch_size,)
+
+        
+        state_size = (2,3)
+        n_state = reduce(*, state_size)
+        total_length = 10
+        t2 = MultiplexTraces{(:state, :next_state)}(
+                reshape(1:n_state * total_length, state_size..., total_length)
+            ) +
+            MultiplexTraces{(:action, :next_action)}(iseven.(1:total_length)) +
+            Traces(
+                reward=1:total_length-1,
+                terminal=Bool[0, 0, 0, 1, 0, 0, 0, 0, 1],
+            )
+
+        xs2 = RLTrajectories.StatsBase.sample(s1, t2)
+
+        @test size(xs2.state) == (state_size..., n_stack, batch_size)
+        @test size(xs2.next_state) == (state_size..., n_stack, batch_size)
+        @test size(xs2.action) == (batch_size,)
+        @test size(xs2.reward) == (batch_size,)
+        @test size(xs2.terminal) == (batch_size,)
+
+        inds = [3, 5, 7]
+        xs3 = RLTrajectories.StatsBase.sample(s1, t2, Val(SS′ART), inds)
+
+        @test xs3.state == cat(
+            (
+                reshape(n_state * (i-n_stack)+1: n_state * i, state_size..., n_stack)
+                for i in inds
+            )...
+            ;dims=length(state_size) + 2
+        ) 
+
+        @test xs3.next_state == xs3.state .+ (n_state * n_horizon)
+        @test xs3.action == iseven.(inds)
+        @test xs3.terminal == [any(t2[:terminal][i: i+n_horizon-1]) for i in inds]
+
+        # manual calculation
+        @test xs3.reward[1] ≈ 3 + γ * 4  # terminated at step 4
+        @test xs3.reward[2] ≈ 5 + γ * (6 + γ * 7)
+        @test xs3.reward[3] ≈ 7 + γ * (8 + γ * 9)
+    end
+    #! format: on
+
+    @testset "Trajectory with CircularPrioritizedTraces and NStepBatchSampler" begin
+        n=1
+        γ=0.99f0
+
+        t = Trajectory(
+            container=CircularPrioritizedTraces(
+                CircularArraySARTSTraces(
+                    capacity=5,
+                    state=Float32 => (4,),
+                );
+                default_priority=100.0f0
+            ),
+            sampler=NStepBatchSampler{SS′ART}(
+                n=n,
+                γ=γ,
+                batch_size=32,
+            ),
+            controller=InsertSampleRatioController(
+                threshold=100,
+                n_inserted=-1
+            )
+        )
+
+        push!(t, (state = 1, action = true))
+        for i = 1:9
+            push!(t, (state = i+1, action = true, reward = i, terminal = false))
+        end
+
+        b = RLTrajectories.StatsBase.sample(t)
+        @test haskey(b, :priority)
+        @test sum(b.action .== 0) == 0
+    end
+
+
+    @testset "Trajectory with CircularArraySARTSTraces and NStepBatchSampler" begin
+        n=1
+        γ=0.99f0
+
+        t = Trajectory(
+            container=CircularArraySARTSTraces(
+                    capacity=5,
+                    state=Float32 => (4,),
+            ),
+            sampler=NStepBatchSampler{SS′ART}(
+                n=n,
+                γ=γ,
+                batch_size=32,
+            ),
+            controller=InsertSampleRatioController(
+                threshold=100,
+                n_inserted=-1
+            )
+        )
+
+        push!(t, (state = 1, action = true))
+        for i = 1:9
+            push!(t, (state = i+1, action = true, reward = i, terminal = false))
+        end
+
+        b = RLTrajectories.StatsBase.sample(t)
+        @test sum(b.action .== 0) == 0
+    end
+
+    #@testset "EpisodesSampler" begin
+        s = EpisodesSampler()
+        eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
+        push!(eb, (state = 1, action = 1))
+        for i = 1:5
+            push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))
+        end
+        push!(eb, (state = 7, action = 7))
+        for (j,i) = enumerate(8:12)
+            push!(eb, (state = i, action =i, reward = i-1, terminal = false))
+        end
+
+        b = sample(s, eb)
+        @test length(b) == 2
+        @test length(b[1][:state]) == 5
+        @test length(b[2][:state]) == 6
+
+        #with specified traces
+        s = EpisodesSampler{(:state,)}()
+        eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
+        push!(eb, (state = 1, action = 1))
+        for i = 1:5
+            push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))
+        end
+        push!(eb, (state = 7, action = 7))
+        for (j,i) = enumerate(8:12)
+            push!(eb, (state = i, action =i, reward = i-1, terminal = false))
+        end
+
+        b = sample(s, eb)
+        @test length(b) == 2
+        @test length(b[1][:state]) == 5
+        @test length(b[2][:state]) == 6
+        @test !haskey(b[1], :action)
+    end
 end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -218,6 +218,14 @@
         @test length(b) == 2
         @test length(b[1][:state]) == 5
         @test length(b[2][:state]) == 6
+        
+        for (j,i) = enumerate(2:5)
+            push!(eb, (state = i, action =i, reward = i-1, terminal = false))
+        end
+        #only the last state of the first episode is still buffered. Should not be sampled.
+        b = sample(s, eb)
+        @test length(b) == 1
+        
 
         #with specified traces
         s = EpisodesSampler{(:state,)}()


### PR DESCRIPTION
This PR adds a new sampler that will sample _all_ the episodes in the Trajectory, even the truncated one (the first episode being typically the only one that's truncated in a limited size buffer). 

The decision to sample all episodes is due to two reasons:
1. Algorithms that use whole episode sampling are typically on-policy algorithms (eg. PPO, TRPO) which means that they use the entirety of the buffered transitions then discard them. As such, there is no reason to sample a subset of the buffer.
2. There is no simple way to sample episodes without replacement from the buffer. As long as no algorithm expressly requires to subset entire Episodes, I don't see a compelling reason to add this functionality.

