### PR TITLE
fix invalid sampling with EpisodesSampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReinforcementLearningTrajectories"
 uuid = "6486599b-a3cd-4e92-a99a-2cea90cc8c3c"
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -258,12 +258,17 @@ end
 StatsBase.sample(s::EpisodesSampler{nothing}, t::EpisodesBuffer) = StatsBase.sample(s,t,keys(t))
 StatsBase.sample(s::EpisodesSampler{names}, t::EpisodesBuffer) where names = StatsBase.sample(s,t,names)
 
+function make_episode(t::EpisodesBuffer, range, names)
+    nt = NamedTuple{names}(map(x -> collect(t[Val(x)][range]), names))
+    Episode(nt)
+end
+
 function StatsBase.sample(::EpisodesSampler, t::EpisodesBuffer, names)
     ranges = UnitRange{Int}[]
     idx = 1
     while idx < length(t)
         if t.sampleable_inds[idx] == 1
-            last_state_idx = idx + t.episodes_lengths[idx] - t.step_numbers[idx] + 1
+            last_state_idx = idx + t.episodes_lengths[idx] - t.step_numbers[idx]
             push!(ranges,idx:last_state_idx)
             idx = last_state_idx + 1
         else
@@ -271,5 +276,5 @@ function StatsBase.sample(::EpisodesSampler, t::EpisodesBuffer, names)
         end
     end
     
-    return [Episode(NamedTuple{names}(map(x -> collect(t[Val(x)][r]), names))) for r in ranges]
+    return [make_episode(t, r, names) for r in ranges]
 end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -14,7 +14,7 @@
         @test size(b.action) == (sz,)
         
         #In EpisodesBuffer
-        eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
+        eb = EpisodesBuffer(CircularArraySARTSATraces(capacity=10)) 
         push!(eb, (state = 1, action = 1))
         for i = 1:5
             push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -1,4 +1,4 @@
-#@testset "Samplers" begin
+@testset "Samplers" begin
     @testset "BatchSampler" begin
         sz = 32
         s = BatchSampler(sz)

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -1,4 +1,4 @@
-@testset "Samplers" begin
+#@testset "Samplers" begin
     @testset "BatchSampler" begin
         sz = 32
         s = BatchSampler(sz)
@@ -205,19 +205,25 @@
     @testset "EpisodesSampler" begin
         s = EpisodesSampler()
         eb = EpisodesBuffer(CircularArraySARTSTraces(capacity=10)) 
-        push!(eb, (state = 1, action = 1))
+        push!(eb, (state = 1,))
         for i = 1:5
-            push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))
+            push!(eb, (state = i+1, action =i, reward = i, terminal = false))
         end
-        push!(eb, (state = 7, action = 7))
+        push!(eb, (state = 7,))
         for (j,i) = enumerate(8:12)
-            push!(eb, (state = i, action =i, reward = i-1, terminal = false))
+            push!(eb, (state = i, action =i-1, reward = i-1, terminal = false))
         end
 
         b = sample(s, eb)
         @test length(b) == 2
-        @test length(b[1][:state]) == 5
-        @test length(b[2][:state]) == 6
+        @test b[1][:state] == [2:5;]
+        @test b[1][:next_state] == [3:6;]
+        @test b[1][:action] == [2:5;]
+        @test b[1][:reward] == [2:5;]
+        @test b[2][:state] == [7:11;]
+        @test b[2][:next_state] == [8:12;]
+        @test b[2][:action] == [7:11;]
+        @test b[2][:reward] == [7:11;]
         
         for (j,i) = enumerate(2:5)
             push!(eb, (state = i, action =i, reward = i-1, terminal = false))
@@ -241,8 +247,8 @@
 
         b = sample(s, eb)
         @test length(b) == 2
-        @test length(b[1][:state]) == 5
-        @test length(b[2][:state]) == 6
+        @test length(b[1][:state]) == 4
+        @test length(b[2][:state]) == 5
         @test !haskey(b[1], :action)
     end
 end


### PR DESCRIPTION
I caught a bug in EpisodesSampler. It used to sample non-multiplex traces at invalid indices due to the range being one too long. This fixes it. I added more complete tests.