### PR TITLE
NStepBatchSampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReinforcementLearningTrajectories"
 uuid = "6486599b-a3cd-4e92-a99a-2cea90cc8c3c"
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/common/sum_tree.jl
+++ b/src/common/sum_tree.jl
@@ -162,7 +162,7 @@ Random.rand(rng::AbstractRNG, t::SumTree{T}) where {T} = get(t, rand(rng, T) * t
 Random.rand(t::SumTree) = rand(Random.GLOBAL_RNG, t)
 
 function Random.rand(rng::AbstractRNG, t::SumTree{T}, n::Int) where {T}
-    inds, priorities = Vector{Int}(undef, n), Vector{Float64}(undef, n)
+    inds, priorities = Vector{Int}(undef, n), Vector{T}(undef, n)
     for i in 1:n
         v = (i - 1 + rand(rng, T)) / n
         ind, p = get(t, v * t.tree[1])

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -163,6 +163,19 @@ end
 
 export NStepBatchSampler
 
+"""
+    NStepBatchSampler{names}(; n, γ, batch_size=32, stack_size=nothing, rng=Random.GLOBAL_RNG)
+
+Used to sample a discounted sum of consecutive rewards in the framework of n-step TD learning.
+The "next" element of Multiplexed traces (such as the next_state or the next_action) will be 
+that in up to `n > 1` steps later in the buffer (or the last of the episode). The reward will be
+the discounted sum of the `n` rewards, with `γ` as the discount factor.
+
+NStepBatchSampler may also be used with n ≥ 1 to sample a "stack" of states if `stack_size` is set 
+to an integer > 1. This samples the (stack_size - 1) previous states. This is useful in the case
+of partial observability, for example when the state is approximated by `stack_size` consecutive 
+frames.
+"""
 mutable struct NStepBatchSampler{traces}
     n::Int # !!! n starts from 1
     γ::Float32
@@ -172,7 +185,10 @@ mutable struct NStepBatchSampler{traces}
 end
 
 NStepBatchSampler(; kw...) = NStepBatchSampler{SS′ART}(; kw...)
-NStepBatchSampler{names}(; n, γ, batch_size=32, stack_size=nothing, rng=Random.GLOBAL_RNG) where {names} = NStepBatchSampler{names}(n, γ, batch_size, stack_size, rng)
+function NStepBatchSampler{names}(; n, γ, batch_size=32, stack_size=nothing, rng=Random.GLOBAL_RNG) where {names} 
+    @assert n >= 1 "n must be ≥ 1."
+    NStepBatchSampler{names}(n, γ, batch_size, stack_size, rng)
+end
 
 
 function valid_range_nbatchsampler(s::NStepBatchSampler, ts)

--- a/src/traces.jl
+++ b/src/traces.jl
@@ -48,7 +48,7 @@ Base.size(x::Trace) = (size(x.parent, ndims(x.parent)),)
 Base.getindex(s::Trace, I) = Base.maybeview(s.parent, ntuple(i -> i == ndims(s.parent) ? I : (:), Val(ndims(s.parent)))...)
 Base.setindex!(s::Trace, v, I) = setindex!(s.parent, v, ntuple(i -> i == ndims(s.parent) ? I : (:), Val(ndims(s.parent)))...)
 
-@forward Trace.parent Base.parent, Base.pushfirst!, Base.push!, Base.append!, Base.prepend!, Base.pop!, Base.popfirst!, Base.empty!
+@forward Trace.parent Base.parent, Base.pushfirst!, Base.push!, Base.append!, Base.prepend!, Base.pop!, Base.popfirst!, Base.empty!, Base.eltype
 
 #By default, AbstractTrace have infinity capacity (like a Vector). This method is specialized for 
 #CircularArraySARTSTraces in common.jl. The functions below are made that way to avoid type piracy.
@@ -94,6 +94,7 @@ Base.getindex(s::RelativeTrace{0,-1}, I) = getindex(s.trace, I)
 Base.getindex(s::RelativeTrace{1,0}, I) = getindex(s.trace, I .+ 1)
 Base.setindex!(s::RelativeTrace{0,-1}, v, I) = setindex!(s.trace, v, I)
 Base.setindex!(s::RelativeTrace{1,0}, v, I) = setindex!(s.trace, v, I .+ 1)
+Base.eltype(t::RelativeTrace) = eltype(t.trace)
 capacity(t::RelativeTrace) = capacity(t.trace)
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using ReinforcementLearningTrajectories
 using CircularArrayBuffers, DataStructures
 using Test
+import ReinforcementLearningTrajectories.StatsBase.sample
 using CUDA
 using Adapt
-import ReinforcementLearningTrajectories.StatsBase.sample
 
 struct TestAdaptor end
 

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -1,5 +1,5 @@
 import ReinforcementLearningTrajectories.fetch
-#@testset "Samplers" begin
+@testset "Samplers" begin
     @testset "BatchSampler" begin
         sz = 32
         s = BatchSampler(sz)


### PR DESCRIPTION
This PR reworks NStepBatchSampler. It now exploits the episode information of EpisodesBuffer.
This was an attempt to solve the issue discussed in https://github.com/JuliaReinforcementLearning/ReinforcementLearning.jl/pull/966. 

It turns out that the issue was not caused by NStepBatchSampler but by the prioritized exp replay. Apparently setting a priority to 0 does not guarantee that the index will never be sampled. So it occasionally happens with low probability. I'll propose a fix to this in another PR to keep things separate. 