### PR TITLE
Sumtree sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,17 +16,18 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Adapt = "3"
 CircularArrayBuffers = "0.1"
+DataStructures = "0.18"
 ElasticArrays = "1"
 MacroTools = "0.5"
 OnlineStats = "1"
 StackViews = "0.1"
-julia = "1.9"
-DataStructures = "0.18"
 StatsBase = "0.34"
+julia = "1.9"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "CUDA"]
+test = ["Test", "CUDA", "StableRNGs"]

--- a/src/common/sum_tree.jl
+++ b/src/common/sum_tree.jl
@@ -131,11 +131,28 @@ function Base.empty!(t::SumTree)
     t
 end
 
+function correct_priority(t::SumTree, leaf_ind)
+    p = t.tree[leaf_ind]
+    # walk backwards until p != 0 or until leftmost leaf reached
+    tmp_ind = leaf_ind
+    while p == 0f0 && (tmp_ind-1)*2 > length(t.tree)
+        tmp_ind -= 1
+        p = t.tree[tmp_ind]
+    end
+    # walk forwards until p != 0 or until rightmost leaf reached
+    p == 0f0 && (tmp_ind = leaf_ind)
+    while p == 0f0 && (tmp_ind - t.nparents) <= t.length
+        tmp_ind += 1
+        p = t.tree[tmp_ind]
+    end
+    return p, tmp_ind
+end
+ 
+
 function Base.get(t::SumTree, v)
     parent_ind = 1
     leaf_ind = parent_ind
     while true
-        v = min(v, t.tree[parent_ind])
         left_child_ind = parent_ind * 2
         right_child_ind = left_child_ind + 1
         if left_child_ind > length(t.tree)
@@ -153,7 +170,7 @@ function Base.get(t::SumTree, v)
     if leaf_ind <= t.nparents
         leaf_ind += t.capacity
     end
-    p = t.tree[leaf_ind]
+    p, leaf_ind = correct_priority(t, leaf_ind)
     ind = leaf_ind - t.nparents
     real_ind = ind >= t.first ? ind - t.first + 1 : ind + t.capacity - t.first + 1
     real_ind, p

--- a/src/common/sum_tree.jl
+++ b/src/common/sum_tree.jl
@@ -135,6 +135,7 @@ function Base.get(t::SumTree, v)
     parent_ind = 1
     leaf_ind = parent_ind
     while true
+        v = min(v, t.tree[parent_ind])
         left_child_ind = parent_ind * 2
         right_child_ind = left_child_ind + 1
         if left_child_ind > length(t.tree)

--- a/src/common/sum_tree.jl
+++ b/src/common/sum_tree.jl
@@ -139,13 +139,13 @@ function correct_sample(t::SumTree, leaf_ind)
     p = t.tree[leaf_ind]
     # walk backwards until p != 0 or until leftmost leaf reached
     tmp_ind = leaf_ind
-    while p == 0f0 && (tmp_ind-1)*2 > length(t.tree)
+    while iszero(p) && (tmp_ind-1)*2 > length(t.tree)
         tmp_ind -= 1
         p = t.tree[tmp_ind]
     end
     # walk forwards until p != 0 or until rightmost leaf reached
-    p == 0f0 && (tmp_ind = leaf_ind)
-    while p == 0f0 && (tmp_ind - t.nparents) <= t.length
+    iszero(p) && (tmp_ind = leaf_ind)
+    while iszero(p) && (tmp_ind - t.nparents) <= t.length
         tmp_ind += 1
         p = t.tree[tmp_ind]
     end

--- a/src/common/sum_tree.jl
+++ b/src/common/sum_tree.jl
@@ -131,7 +131,11 @@ function Base.empty!(t::SumTree)
     t
 end
 
-function correct_priority(t::SumTree, leaf_ind)
+"""
+    correct_sample(t::SumTree, leaf_ind)
+Check whether the sampled leaf is valid and if not return another valid leaf close to it. Used to correct samples with zero priority which may occur due to numerical errors with floats.
+"""
+function correct_sample(t::SumTree, leaf_ind)
     p = t.tree[leaf_ind]
     # walk backwards until p != 0 or until leftmost leaf reached
     tmp_ind = leaf_ind
@@ -170,7 +174,7 @@ function Base.get(t::SumTree, v)
     if leaf_ind <= t.nparents
         leaf_ind += t.capacity
     end
-    p, leaf_ind = correct_priority(t, leaf_ind)
+    p, leaf_ind = correct_sample(t, leaf_ind)
     ind = leaf_ind - t.nparents
     real_ind = ind >= t.first ? ind - t.first + 1 : ind + t.capacity - t.first + 1
     real_ind, p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,12 @@
 using ReinforcementLearningTrajectories
 using CircularArrayBuffers, DataStructures
+using StableRNGs
 using Test
 using CUDA
 using Adapt
+using Random
 import ReinforcementLearningTrajectories.StatsBase.sample
+import StatsBase.countmap
 
 struct TestAdaptor end
 
@@ -13,6 +16,7 @@ Adapt.adapt_storage(to::TestAdaptor, x) = CUDA.functional() ? CUDA.cu(x) : x
 
 @testset "ReinforcementLearningTrajectories.jl" begin
     include("traces.jl")
+    include("sum_tree.jl")
     include("common.jl")
     include("samplers.jl")
     include("controllers.jl")

--- a/test/sum_tree.jl
+++ b/test/sum_tree.jl
@@ -57,6 +57,6 @@ abstol = 0.05
 maxerr=0.01
 sumtree_distribution(n, seeds, distr_iters)
 
-# @test sumtree_nozero(n, seeds, nozero_iters)
-# @test all(x->all(x .< maxerr) && sum(abs2, x) < abstol,
-#           sumtree_distribution(n, seeds, distr_iters))
+@test sumtree_nozero(n, seeds, nozero_iters)
+@test all(x->all(x .< maxerr) && sum(abs2, x) < abstol,
+          sumtree_distribution(n, seeds, distr_iters))

--- a/test/sum_tree.jl
+++ b/test/sum_tree.jl
@@ -49,13 +49,15 @@ function sumtree_distribution(n, seeds::AbstractVector, iters=1000*n)
     return results
 end
 
-n = 1024
-seeds = 1:100
-nozero_iters=1024
-distr_iters=1024*10_000
-abstol = 0.05
-maxerr=0.01
+@testset "SumTree" begin
+    n = 1024
+    seeds = 1:100
+    nozero_iters=1024
+    distr_iters=1024*10_000
+    abstol = 0.05
+    maxerr=0.01
 
-@test sumtree_nozero(n, seeds, nozero_iters)
-@test all(x->all(x .< maxerr) && sum(abs2, x) < abstol,
-          sumtree_distribution(n, seeds, distr_iters))
+    @test sumtree_nozero(n, seeds, nozero_iters)
+    @test all(x->all(x .< maxerr) && sum(abs2, x) < abstol,
+            sumtree_distribution(n, seeds, distr_iters))
+end

--- a/test/sum_tree.jl
+++ b/test/sum_tree.jl
@@ -1,0 +1,62 @@
+function gen_rand_sumtree(n, seed, type::DataType=Float32)
+    rng = StableRNG(seed)
+    a = SumTree(type, n)
+    append!(a, rand(rng, type, n))
+    return a
+end
+
+function gen_sumtree_with_zeros(n, seed, type::DataType=Float32)
+    a = gen_rand_sumtree(n, seed, type)
+    b = rand(StableRNG(seed), Bool, n)
+    return copy_multiply(a, b)
+end 
+
+function copy_multiply(stree, m)
+    new_tree = deepcopy(stree)
+    new_tree .*= m
+    return new_tree
+end
+
+function sumtree_nozero(t::SumTree, rng::AbstractRNG, iters=1)
+    for _ in iters
+        (_, p) = rand(rng, t)
+        p == 0 && return false
+    end
+    return true
+end
+sumtree_nozero(n::Integer, seed::Integer, iters=1) = sumtree_nozero(gen_sumtree_with_zeros(n, seed), StableRNG(seed), iters)
+sumtree_nozero(n, seeds::AbstractVector, iters=1) = all(sumtree_nozero(n, seed, iters) for seed in seeds)
+
+
+function sumtree_distribution!(indices, priorities, t::SumTree, rng::AbstractRNG, iters=1000*t.length)
+    for i = 1:iters
+        indices[i], priorities[i] = rand(rng, t)
+    end
+    imap = countmap(indices)
+    est_pdf = Dict(k=>v/length(indices) for (k, v) in imap)
+    ex_pdf = Dict(k=>v/t.tree[1] for (k, v) in Dict(1:length(t) .=> t))
+    abserrs = [est_pdf[k] - ex_pdf[k] for k in keys(est_pdf)]
+    return abserrs
+end
+sumtree_distribution!(indices, priorities, n, seed, iters=1000*n) = sumtree_distribution!(indices, priorities, gen_rand_sumtree(n, seed), StableRNG(seed), iters)
+function sumtree_distribution(n, seeds::AbstractVector, iters=1000*n)
+    p = [zeros(Float32, iters) for _ = 1:Threads.nthreads()]
+    i = [zeros(Float32, iters) for _ = 1:Threads.nthreads()]
+    results = Vector{Vector{Float64}}(undef, length(seeds))
+    Threads.@threads for ix = 1:length(seeds)
+        results[ix] = sumtree_distribution!(i[Threads.threadid()], p[Threads.threadid()], gen_rand_sumtree(n, seeds[ix]), StableRNG(seeds[ix]), iters)
+    end
+    return results
+end
+
+n = 1024
+seeds = 1:100
+nozero_iters=1024
+distr_iters=1024*10_000
+abstol = 0.05
+maxerr=0.01
+sumtree_distribution(n, seeds, distr_iters)
+
+# @test sumtree_nozero(n, seeds, nozero_iters)
+# @test all(x->all(x .< maxerr) && sum(abs2, x) < abstol,
+#           sumtree_distribution(n, seeds, distr_iters))

--- a/test/sum_tree.jl
+++ b/test/sum_tree.jl
@@ -55,7 +55,6 @@ nozero_iters=1024
 distr_iters=1024*10_000
 abstol = 0.05
 maxerr=0.01
-sumtree_distribution(n, seeds, distr_iters)
 
 @test sumtree_nozero(n, seeds, nozero_iters)
 @test all(x->all(x .< maxerr) && sum(abs2, x) < abstol,


### PR DESCRIPTION
For all the lofty talk about numerical rounding errors in #59, they are unavoidable even with the improved method. This fix simply checks whether the sampled priority happens to be zero, and if so it walks backwards over the leafs until it finds a nonzero priority node. If the backwards walk has not found anything, it performs a forward walk instead.

This has been tested against the [`JuliaRL_PrioritizedDQN_CartPole` experiment in ReinforcementLearningExperiments.jl](https://github.com/JuliaReinforcementLearning/ReinforcementLearning.jl/blob/main/src/ReinforcementLearningExperiments/deps/experiments/experiments/DQN/JuliaRL_PrioritizedDQN_CartPole.jl) with 30 different seeds.