### PR TITLE
Remove special handling of SARTSA traces

### DIFF
--- a/src/common/CircularArraySARTSATraces.jl
+++ b/src/common/CircularArraySARTSATraces.jl
@@ -24,12 +24,12 @@ function CircularArraySARTSATraces(;
     reward_eltype, reward_size = reward
     terminal_eltype, terminal_size = terminal
 
-    MultiplexTraces{SS′}(CircularArrayBuffer{state_eltype}(state_size..., capacity+2)) +
+    MultiplexTraces{SS′}(CircularArrayBuffer{state_eltype}(state_size..., capacity+1)) +
     MultiplexTraces{AA′}(CircularArrayBuffer{action_eltype}(action_size..., capacity+1)) +
     Traces(
-        reward=CircularArrayBuffer{reward_eltype}(reward_size..., capacity+1),
-        terminal=CircularArrayBuffer{terminal_eltype}(terminal_size..., capacity+1),
+        reward=CircularArrayBuffer{reward_eltype}(reward_size..., capacity),
+        terminal=CircularArrayBuffer{terminal_eltype}(terminal_size..., capacity),
     )
 end
 
-CircularArrayBuffers.capacity(t::CircularArraySARTSATraces) = CircularArrayBuffers.capacity(minimum(map(capacity,t.traces)))
+CircularArrayBuffers.capacity(t::CircularArraySARTSATraces) = minimum(map(capacity,t.traces))

--- a/src/common/CircularArraySARTSTraces.jl
+++ b/src/common/CircularArraySARTSTraces.jl
@@ -17,8 +17,8 @@ function CircularArraySARTSTraces(;
     state=Int => (),
     action=Int => (),
     reward=Float32 => (),
-    terminal=Bool => ())
-    
+    terminal=Bool => ()
+)
     state_eltype, state_size = state
     action_eltype, action_size = action
     reward_eltype, reward_size = reward
@@ -32,4 +32,4 @@ function CircularArraySARTSTraces(;
     )
 end
 
-CircularArrayBuffers.capacity(t::CircularArraySARTSTraces) = CircularArrayBuffers.capacity(minimum(map(capacity,t.traces)))
+CircularArrayBuffers.capacity(t::CircularArraySARTSTraces) = minimum(map(capacity,t.traces))

--- a/src/common/CircularArraySLARTTraces.jl
+++ b/src/common/CircularArraySLARTTraces.jl
@@ -34,4 +34,4 @@ function CircularArraySLARTTraces(;
     )
 end
 
-CircularArrayBuffers.capacity(t::CircularArraySLARTTraces) = CircularArrayBuffers.capacity(minimum(map(capacity,t.traces)))
+CircularArrayBuffers.capacity(t::CircularArraySLARTTraces) = minimum(map(capacity,t.traces))

--- a/src/common/CircularPrioritizedTraces.jl
+++ b/src/common/CircularPrioritizedTraces.jl
@@ -12,11 +12,7 @@ end
 function CircularPrioritizedTraces(traces::AbstractTraces{names,Ts}; default_priority) where {names,Ts}
     new_names = (:key, :priority, names...)
     new_Ts = Tuple{Int,Float32,Ts.parameters...}
-    if traces isa CircularArraySARTSATraces
-        c = capacity(traces) - 1
-    else
-        c = capacity(traces)
-    end
+    c = capacity(traces)
     CircularPrioritizedTraces{typeof(traces),new_names,new_Ts}(
         CircularVectorBuffer{Int}(c),
         SumTree(c),

--- a/src/common/CircularPrioritizedTraces.jl
+++ b/src/common/CircularPrioritizedTraces.jl
@@ -34,22 +34,6 @@ function Base.push!(t::CircularPrioritizedTraces, x)
     end
 end
 
-function Base.push!(t::CircularPrioritizedTraces{<:CircularArraySARTSATraces}, x)
-    initial_length = length(t.traces)
-    push!(t.traces, x)
-    if length(t.traces) == 1
-        push!(t.keys, 1)
-        push!(t.priorities, t.default_priority)
-    elseif length(t.traces) > 1 && (initial_length < length(t.traces) || initial_length == capacity(t.traces)-1 ) 
-        # only add a key if the length changes after insertion of the tuple
-        # or if the trace is already at capacity
-        push!(t.keys, t.keys[end] + 1)
-        push!(t.priorities, t.default_priority)
-    else
-        # may be partial inserting at the first step, ignore it
-    end
-end
-
 function Base.setindex!(t::CircularPrioritizedTraces, vs, k::Symbol, keys)
     if k === :priority
         @assert length(vs) == length(keys)

--- a/src/episodes.jl
+++ b/src/episodes.jl
@@ -5,9 +5,9 @@ using ElasticArrays: ElasticArray, ElasticVector
 """
     EpisodesBuffer(traces::AbstractTraces)
 
-Wraps an `AbstractTraces` object, usually the container of a `Trajectory`. 
+Wraps an `AbstractTraces` object, usually the container of a `Trajectory`.
 `EpisodesBuffer` tracks the indexes of the `traces` object that belong to the same episodes.
-To that end, it stores 
+To that end, it stores
 1. an vector `sampleable_inds` of Booleans that determine whether an index in Traces is legally sampleable
 (i.e., it is not the index of a last state of an episode);
 2. a vector `episodes_lengths` that contains the total duration of the episode that each step belong to;
@@ -32,7 +32,7 @@ end
 """
     PartialNamedTuple(::NamedTuple)
 
-Wraps a NamedTuple to signal an EpisodesBuffer that it is pushed into that it should 
+Wraps a NamedTuple to signal an EpisodesBuffer that it is pushed into that it should
 ignore the fact that this is a partial insertion. Used at the end of an episode to
 complete multiplex traces before moving to the next episode.
 """
@@ -118,8 +118,6 @@ pad!(vect::Vector{T}) where {T} = push!(vect, zero(T))
         end
     elseif traces_signature <: Tuple
         traces_signature = traces_signature.parameters
-        
-    
         for tr in traces_signature
             if !(tr <: MultiplexTraces)
                 #push a duplicate of last element as a dummy element, should never be sampled.
@@ -171,7 +169,7 @@ function Base.push!(eb::EpisodesBuffer, xs::NamedTuple)
     return nothing
 end
 
-function Base.push!(eb::EpisodesBuffer, xs::PartialNamedTuple) #wrap a NamedTuple to push without incrementing the step number. 
+function Base.push!(eb::EpisodesBuffer, xs::PartialNamedTuple) #wrap a NamedTuple to push without incrementing the step number.
     push!(eb.traces, xs.namedtuple)
     eb.sampleable_inds[end-1] = 1 #completes the episode trajectory.
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -180,14 +180,14 @@ end
         default_priority=1.0f0
     )
 
-    eb = EpisodesBuffer(t) 
+    eb = EpisodesBuffer(t)
     push!(eb, (state = 1, action = 1))
     for i = 1:5
-        push!(eb, (state = i+1, action =i+1, reward = i, terminal = false))
+        push!(eb, (state = i+1, action = i+1, reward = i, terminal = false))
     end
     push!(eb, (state = 7, action = 7))
     for (j,i) = enumerate(8:11)
-        push!(eb, (state = i, action =i, reward = i-1, terminal = false))
+        push!(eb, (state = i, action = i, reward = i-1, terminal = false))
     end
     s = BatchSampler(1000)
     b = sample(s, eb)
@@ -222,6 +222,8 @@ end
 
     b = sample(s, t)
 
+    @test t[:priority] == [1.0f0, 1.0f0, 1.0f0]
+
     t[:priority, [1, 2]] = [0, 0]
 
     # shouldn't be changed since [1,2] are old keys
@@ -240,18 +242,19 @@ end
         ),
         default_priority=1.0f0
     )
-    
-    eb = EpisodesBuffer(t) 
+
+    eb = EpisodesBuffer(t)
     push!(eb, (state = 1,))
     for i = 1:5
-        push!(eb, (state = i+1, action =i, reward = i, terminal = false))
+        push!(eb, (state = i+1, action = i, reward = i, terminal = false))
     end
     push!(eb, PartialNamedTuple((action = 6,)))
     push!(eb, (state = 7,))
-    for (j,i) = enumerate(8:11)
-        push!(eb, (state = i, action =i-1, reward = i-1, terminal = false))
+    for i = 8:11
+        push!(eb, (state = i, action = i-1, reward = i-1, terminal = false))
     end
-    push!(eb, PartialNamedTuple((action=12,)))
+    push!(eb, PartialNamedTuple((action=11,)))
+
     s = BatchSampler(1000)
     b = sample(s, eb)
     cm = counter(b[:state])

--- a/test/common.jl
+++ b/test/common.jl
@@ -34,15 +34,20 @@ end
     ) |> gpu
 
     @test t isa CircularArraySARTSATraces
+    @test ReinforcementLearningTrajectories.capacity(t) == 3
+    @test CircularArrayBuffers.capacity(t) == 3
 
-    push!(t, (state=ones(Float32, 2, 3),))
+    push!(t, (state=ones(Float32, 2, 3),) |> gpu)
     push!(t, (action=ones(Float32, 2), next_state=ones(Float32, 2, 3) * 2) |> gpu)
     @test length(t) == 0
 
     push!(t, (reward=1.0f0, terminal=false) |> gpu)
     @test length(t) == 0 # next_action is still missing
 
-    push!(t, (state=ones(Float32, 2, 3) * 3, action=ones(Float32, 2) * 2) |> gpu)
+    push!(t, (action=ones(Float32, 2) * 2,) |> gpu)
+    @test length(t) == 1
+
+    push!(t, (state=ones(Float32, 2, 3) * 3,) |> gpu)
     @test length(t) == 1
 
     # this will trigger the scalar indexing of CuArray
@@ -71,29 +76,33 @@ end
 
     @test length(t) == 3
 
+    push!(t, (action=ones(Float32, 2) * 6,) |> gpu)
+    @test length(t) == 3
+
     # this will trigger the scalar indexing of CuArray
     CUDA.@allowscalar @test t[1] == (
-        state=ones(Float32, 2, 3) * 2,
-        next_state=ones(Float32, 2, 3) * 3,
-        action=ones(Float32, 2) * 2,
-        next_action=ones(Float32, 2) * 3,
-        reward=2.0f0,
+        state=ones(Float32, 2, 3) * 3,
+        next_state=ones(Float32, 2, 3) * 4,
+        action=ones(Float32, 2) * 3,
+        next_action=ones(Float32, 2) * 4,
+        reward=3.0f0,
         terminal=false,
     )
     CUDA.@allowscalar @test t[end] == (
-        state=ones(Float32, 2, 3) * 4,
-        next_state=ones(Float32, 2, 3) * 5,
-        action=ones(Float32, 2) * 4,
-        next_action=ones(Float32, 2) * 5,
-        reward=4.0f0,
+        state=ones(Float32, 2, 3) * 5,
+        next_state=ones(Float32, 2, 3) * 6,
+        action=ones(Float32, 2) * 5,
+        next_action=ones(Float32, 2) * 6,
+        reward=5.0f0,
         terminal=false,
     )
 
     batch = t[1:3]
     @test size(batch.state) == (2, 3, 3)
     @test size(batch.action) == (2, 3)
-    @test batch.reward == [2.0, 3.0, 4.0] |> gpu
+    @test batch.reward == [3.0, 4.0, 5.0] |> gpu
     @test batch.terminal == Bool[0, 0, 0] |> gpu
+
 end
 
 @testset "ElasticArraySARTSTraces" begin
@@ -127,6 +136,8 @@ end
     )
 
     @test t isa CircularArraySLARTTraces
+    @test ReinforcementLearningTrajectories.capacity(t) == 3
+    @test CircularArrayBuffers.capacity(t) == 3
 end
 
 @testset "CircularPrioritizedTraces-SARTS" begin
@@ -136,6 +147,7 @@ end
         ),
         default_priority=1.0f0
     )
+    @test ReinforcementLearningTrajectories.capacity(t) == 3
 
     push!(t, (state=0, action=0))
 
@@ -196,6 +208,7 @@ end
         ),
         default_priority=1.0f0
     )
+    @test ReinforcementLearningTrajectories.capacity(t) == 3
 
     push!(t, (state=0, action=0))
 

--- a/test/episodes.jl
+++ b/test/episodes.jl
@@ -3,54 +3,65 @@ using CircularArrayBuffers
 using Test
 
 @testset "EpisodesBuffer" begin
-    @testset "with circular traces" begin 
+    @testset "with circular SARTS traces" begin
         eb = EpisodesBuffer(
             CircularArraySARTSTraces(;
             capacity=10)
         )
-        #push a first episode l=5 
+
+        # push first episode (five steps)
         push!(eb, (state = 1,))
         @test eb.sampleable_inds[end] == 0
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
         for i = 1:5
-            push!(eb, (state = i+1, action =i, reward = i, terminal = false))
+            push!(eb, (state = i+1, action = i, reward = i, terminal = false))
             @test eb.sampleable_inds[end] == 0
             @test eb.sampleable_inds[end-1] == 1
             @test eb.step_numbers[end] == i + 1
             @test eb.episodes_lengths[end-i:end] == fill(i, i+1)
         end
+        @test eb[end] == (state = 5, next_state = 6, action = 5, reward = 5, terminal = false)
         @test eb.sampleable_inds == [1,1,1,1,1,0]
         @test length(eb.traces) == 5
-        #start new episode of 6 periods.
+
+        # start second episode
         push!(eb, (state = 7,))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
         @test eb.sampleable_inds == [1,1,1,1,1,0,0]
-        @test eb[6][:reward] == 0 #6 is not a valid index, the reward there is filled as zero
+        @test eb[:reward][6] == 0 # 6 is not a valid index, filled with dummy value zero
+        @test_throws BoundsError eb[6] # 6 is not a valid index
+        @test_throws BoundsError eb[7] # 7 is not a valid index
+
+        # push four steps of second episode
         ep2_len = 0
-        for (j,i) = enumerate(8:11)
+        for (i,s) = enumerate(8:11)
             ep2_len += 1
-            push!(eb, (state = i, action =i-1, reward = i-1, terminal = false))
+            push!(eb, (state = s, action = s-1, reward = s-1, terminal = false))
             @test eb.sampleable_inds[end] == 0
             @test eb.sampleable_inds[end-1] == 1
-            @test eb.step_numbers[end] == j + 1
-            @test eb.episodes_lengths[end-j:end] == fill(ep2_len, ep2_len + 1)
+            @test eb.step_numbers[end] == i + 1
+            @test eb.episodes_lengths[end-i:end] == fill(ep2_len, ep2_len + 1)
         end
+        @test eb[end] == (state = 10, next_state = 11, action = 10, reward = 10, terminal = false)
         @test eb.sampleable_inds == [1,1,1,1,1,0,1,1,1,1,0]
-        @test length(eb.traces) == 10
-        #three last steps replace oldest steps in the buffer.
+        @test length(eb) == 10
+        # push two more steps of second episode, which replace the oldest steps in the buffer
         for (i, s) = enumerate(12:13)
             ep2_len += 1
-            push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
+            push!(eb, (state = s, action = s-1, reward = s-1, terminal = false))
             @test eb.sampleable_inds[end] == 0
             @test eb.sampleable_inds[end-1] == 1
             @test eb.step_numbers[end] == i + 1 + 4
             @test eb.episodes_lengths[end-ep2_len:end] == fill(ep2_len, ep2_len + 1)
         end
-        #episode 1
+        @test eb[end] == (state = 12, next_state = 13, action = 12, reward = 12, terminal = false)
+        @test eb.sampleable_inds == [1,1,1,0,1,1,1,1,1,1,0]
+
+        # verify episode 2
         for (i,s) in enumerate(3:13)
             if i in (4, 11)
                 @test eb.sampleable_inds[i] == 0
@@ -62,8 +73,8 @@ using Test
             @test b[:state] == b[:action] == b[:reward] == s
             @test b[:next_state] == s + 1
         end
-        #episode 2
-        #start a third episode
+
+        # push third episode
         push!(eb, (state = 14, ))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
@@ -71,28 +82,28 @@ using Test
         @test eb.step_numbers[end] == 1
         #push until it reaches it own start
         for (i,s) in enumerate(15:26)
-            push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
+            push!(eb, (state = s, action = s-1, reward = s-1, terminal = false))
         end
         @test eb.sampleable_inds == [fill(true, 10); [false]]
         @test eb.episodes_lengths == fill(length(15:26), 11)
         @test eb.step_numbers == [3:13;]
-        step = popfirst!(eb)
+        popfirst!(eb)
         @test length(eb) == length(eb.sampleable_inds) - 1 == length(eb.step_numbers) - 1 == length(eb.episodes_lengths) - 1 == 9
         @test first(eb.step_numbers) == 4
-        step = pop!(eb)
+        pop!(eb)
         @test length(eb) == length(eb.sampleable_inds) - 1 == length(eb.step_numbers) - 1 == length(eb.episodes_lengths) - 1 == 8
         @test last(eb.step_numbers) == 12
         @test size(eb) == size(eb.traces) == (8,)
         empty!(eb)
         @test size(eb) == (0,) == size(eb.traces) == size(eb.sampleable_inds) == size(eb.episodes_lengths) == size(eb.step_numbers)
-        show(eb); 
     end
-    @testset "with PartialNamedTuple" begin 
+
+    @testset "with SARTSA traces and PartialNamedTuple" begin
         eb = EpisodesBuffer(
             CircularArraySARTSATraces(;
             capacity=10)
         )
-        #push a first episode l=5 
+        # push first episode (five steps)
         push!(eb, (state = 1,))
         @test eb.sampleable_inds[end] == 0
         @test eb.episodes_lengths[end] == 0
@@ -107,38 +118,46 @@ using Test
             @test eb.step_numbers[end] == i + 1
             @test eb.episodes_lengths[end-i:end] == fill(i, i+1)
         end
+        @test eb.sampleable_inds == [1,1,1,1,0,0]
         push!(eb, PartialNamedTuple((action = 6,)))
         @test eb.sampleable_inds == [1,1,1,1,1,0]
         @test length(eb.traces) == 5
-        #start new episode of 6 periods.
+
+        # start second episode
         push!(eb, (state = 7,))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
         @test eb.sampleable_inds == [1,1,1,1,1,0,0]
-        @test eb[:action][6] == 6
-        @test eb[:next_action][5] == 6
-        @test eb[:reward][6] == 0 #6 is not a valid index, the reward there is dummy, filled as zero
-        @test_throws BoundsError eb[6]  #6 is not a valid index, the reward there is dummy, filled as zero
+        @test eb[5][:next_action] == eb[:next_action][5] == 6
+        @test eb[:reward][6] == 0 # 6 is not a valid index, the reward there is dummy, filled as zero
+        @test_throws BoundsError eb[6]  # 6 is not a valid index
         ep2_len = 0
-        for (j,i) = enumerate(8:11)
+        # push four steps of second episode
+        for (i,s) = enumerate(8:11)
             ep2_len += 1
-            push!(eb, (state = i, action =i-1, reward = i-1, terminal = false))
+            push!(eb, (state = s, action = s-1, reward = s-1, terminal = false))
             @test eb.sampleable_inds[end] == 0
             @test eb.sampleable_inds[end-1] == 0
             if eb.step_numbers[end] > 2
                 @test eb.sampleable_inds[end-2] == 1
             end
-            @test eb.step_numbers[end] == j + 1
-            @test eb.episodes_lengths[end-j:end] == fill(ep2_len, ep2_len + 1)
+            @test eb.step_numbers[end] == i + 1
+            @test eb.episodes_lengths[end-i:end] == fill(ep2_len, ep2_len + 1)
         end
         @test eb.sampleable_inds == [1,1,1,1,1,0,1,1,1,0,0]
-        @test length(eb.traces) == 9 #an action is missing at this stage
-        #three last steps replace oldest steps in the buffer.
+        @test length(eb.traces) == 9 # an action is missing at this stage
+        @test eb.sampleable_inds[end] == 0
+        @test eb.sampleable_inds[end-1] == 0
+        if eb.step_numbers[end] > 2
+            @test eb.sampleable_inds[end-2] == 1
+        end
+
+        # push two more steps of second episode, which replace the oldest steps in the buffer
         for (i, s) = enumerate(12:13)
             ep2_len += 1
-            push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
+            push!(eb, (state = s, action = s-1, reward = s-1, terminal = false))
             @test eb.sampleable_inds[end] == 0
             @test eb.sampleable_inds[end-1] == 0
             if eb.step_numbers[end] > 2
@@ -149,7 +168,8 @@ using Test
         end
         push!(eb, PartialNamedTuple((action = 13,)))
         @test length(eb.traces) == 10
-        #episode 1
+
+        # verify episode 2
         for (i,s) in enumerate(3:13)
             if i in (4, 11)
                 @test eb.sampleable_inds[i] == 0
@@ -161,16 +181,16 @@ using Test
             @test b[:state] == b[:action] == b[:reward] == s
             @test b[:next_state] == b[:next_action] == s + 1
         end
-        #episode 2
-        #start a third episode
+
+        # push third episode
         push!(eb, (state = 14,))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
-        #push until it reaches it own start
+        # push until it reaches it own start
         for (i,s) in enumerate(15:26)
-            push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
+            push!(eb, (state = s, action = s-1, reward = s-1, terminal = false))
         end
         push!(eb, PartialNamedTuple((action = 26,)))
         @test eb.sampleable_inds == [fill(true, 10); [false]]
@@ -185,7 +205,6 @@ using Test
         @test size(eb) == size(eb.traces) == (8,)
         empty!(eb)
         @test size(eb) == (0,) == size(eb.traces) == size(eb.sampleable_inds) == size(eb.episodes_lengths) == size(eb.step_numbers)
-        show(eb); 
     end
     @testset "with vector traces" begin
         eb = EpisodesBuffer(
@@ -193,7 +212,7 @@ using Test
                 state=Int[],
                 reward=Int[])
         )
-        push!(eb, (state = 1,)) #partial inserting
+        push!(eb, (state = 1,)) # partial inserting
         for i = 1:15
             push!(eb, (state = i+1, reward =i))
         end
@@ -201,7 +220,7 @@ using Test
         @test eb.sampleable_inds == [fill(true, 15); [false]]
         @test all(==(15), eb.episodes_lengths)
         @test eb.step_numbers == [1:16;]
-        push!(eb, (state = 1,)) #partial inserting
+        push!(eb, (state = 1,)) # partial inserting
         for i = 1:15
             push!(eb, (state = i+1, reward =i))
         end
@@ -210,11 +229,12 @@ using Test
         @test eb.step_numbers == [1:16;1:16]
         @test length(eb) == 31
     end
-    @testset "with ElasticArraySARTSTraces traces" begin 
+
+    @testset "with ElasticArraySARTSTraces" begin
         eb = EpisodesBuffer(
             ElasticArraySARTSTraces()
         )
-        #push a first episode l=5 
+        # push first episode (five steps)
         push!(eb, (state = 1,))
         @test eb.sampleable_inds[end] == 0
         @test eb.episodes_lengths[end] == 0
@@ -228,15 +248,18 @@ using Test
         end
         @test eb.sampleable_inds == [1,1,1,1,1,0]
         @test length(eb.traces) == 5
-        #start new episode of 6 periods.
+
+        # start second episode
         push!(eb, (state = 7,))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
         @test eb.sampleable_inds == [1,1,1,1,1,0,0]
-        @test eb[6][:reward] == 0 #6 is not a valid index, the reward there is filled as zero
+        @test eb[:reward][6] == 0 #6 is not a valid index, the reward there is dummy, filled as zero
+        @test_throws BoundsError eb[6]  #6 is not a valid index
         ep2_len = 0
+        # push four steps of second episode
         for (j,i) = enumerate(8:11)
             ep2_len += 1
             push!(eb, (state = i, action =i-1, reward = i-1, terminal = false))
@@ -248,6 +271,7 @@ using Test
         @test eb.sampleable_inds == [1,1,1,1,1,0,1,1,1,1,0]
         @test length(eb.traces) == 10
 
+        # push two more steps of second episode, which replace the oldest steps in the buffer
         for (i, s) = enumerate(12:13)
             ep2_len += 1
             push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
@@ -256,7 +280,7 @@ using Test
             @test eb.step_numbers[end] == i + 1 + 4
             @test eb.episodes_lengths[end-ep2_len:end] == fill(ep2_len, ep2_len + 1)
         end
-        #episode 1
+        # verify episode 2
         for i in 3:13
             if i in (6, 13)
                 @test eb.sampleable_inds[i] == 0
@@ -268,14 +292,15 @@ using Test
             @test b[:state] == b[:action] == b[:reward] == i
             @test b[:next_state] == i + 1
         end
-        #episode 2
-        #start a third episode
+
+        # push third episode
         push!(eb, (state = 14, ))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
         @test eb.episodes_lengths[end] == 0
         @test eb.step_numbers[end] == 1
 
+        # push until it reaches it own start
         for (i,s) in enumerate(15:26)
             push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
         end
@@ -292,15 +317,14 @@ using Test
         @test size(eb) == size(eb.traces) == (8,)
         empty!(eb)
         @test size(eb) == (0,) == size(eb.traces) == size(eb.sampleable_inds) == size(eb.episodes_lengths) == size(eb.step_numbers)
-        show(eb); 
         =#
     end
 
-    @testset "ElasticArraySARTSATraces with PartialNamedTuple" begin 
+    @testset "ElasticArraySARTSATraces with PartialNamedTuple" begin
         eb = EpisodesBuffer(
             ElasticArraySARTSATraces()
         )
-        #push a first episode l=5 
+        # push first episode (five steps)
         push!(eb, (state = 1,))
         @test eb.sampleable_inds[end] == 0
         @test eb.episodes_lengths[end] == 0
@@ -318,7 +342,8 @@ using Test
         push!(eb, PartialNamedTuple((action = 6,)))
         @test eb.sampleable_inds == [1,1,1,1,1,0]
         @test length(eb.traces) == 5
-        #start new episode of 6 periods.
+
+        # start second episode
         push!(eb, (state = 7,))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
@@ -329,6 +354,7 @@ using Test
         @test eb[:next_action][5] == 6
         @test eb[:reward][6] == 0 #6 is not a valid index, the reward there is dummy, filled as zero
         ep2_len = 0
+        # push four steps of second episode
         for (j,i) = enumerate(8:11)
             ep2_len += 1
             push!(eb, (state = i, action =i-1, reward = i-1, terminal = false))
@@ -341,7 +367,8 @@ using Test
             @test eb.episodes_lengths[end-j:end] == fill(ep2_len, ep2_len + 1)
         end
         @test eb.sampleable_inds == [1,1,1,1,1,0,1,1,1,0,0]
-        @test length(eb.traces) == 9 #an action is missing at this stage
+        @test length(eb.traces) == 9 # an action is missing at this stage
+        # push two more steps of second episode, which replace the oldest steps in the buffer
         for (i, s) = enumerate(12:13)
             ep2_len += 1
             push!(eb, (state = s, action =s-1, reward = s-1, terminal = false))
@@ -355,7 +382,8 @@ using Test
         end
         push!(eb, PartialNamedTuple((action = 13,)))
         @test length(eb.traces) == 12
-        #episode 1
+
+        # verify episode 2
         for i in 1:13
             if i in (6, 13)
                 @test eb.sampleable_inds[i] == 0
@@ -367,8 +395,8 @@ using Test
             @test b[:state] == b[:action] == b[:reward] == i
             @test b[:next_state] == b[:next_action] == i + 1
         end
-        #episode 2
-        #start a third episode
+
+        # push third episode
         push!(eb, (state = 14,))
         @test eb.sampleable_inds[end] == 0
         @test eb.sampleable_inds[end-1] == 0
@@ -392,7 +420,6 @@ using Test
         @test size(eb) == size(eb.traces) == (8,)
         empty!(eb)
         @test size(eb) == (0,) == size(eb.traces) == size(eb.sampleable_inds) == size(eb.episodes_lengths) == size(eb.step_numbers)
-        show(eb); 
         =#
     end
 end


### PR DESCRIPTION
This MR contains several things:

- fixing the `capacity` function for  predefined traces like `CircularArraySARTSTraces` etc. https://github.com/JuliaReinforcementLearning/ReinforcementLearningTrajectories.jl/commit/e924768499c973ab83f6749d73b596112ff2dc18
- reducing the capacity of the traces in `CircularArraySARTSATraces` to only the necessary capacity (exactly one additional state and action) https://github.com/JuliaReinforcementLearning/ReinforcementLearningTrajectories.jl/commit/e924768499c973ab83f6749d73b596112ff2dc18
- removing special code for SARTSA traces and make it work with the generic code https://github.com/JuliaReinforcementLearning/ReinforcementLearningTrajectories.jl/commit/bfc15918b5bc6d93bb632e52a862a42ee0f68baa
  - `Base.push!(t::CircularPrioritizedTraces{<:CircularArraySARTSATraces}, x)` and `
  - `Base.push!(eb::EpisodesBuffer{<:Any,<:Any,<:CircularArraySARTSATraces}, xs::PartialNamedTuple)`
  - `function Base.push!(eb::EpisodesBuffer{<:Any,<:Any,<:CircularPrioritizedTraces{<:CircularArraySARTSATraces}}, xs::PartialNamedTuple{@NamedTuple{action::Int64}})`